### PR TITLE
Add CI and immutable prerelease automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: fmt, clippy, test, build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect Rust workspace
+        id: project
+        run: |
+          if [ -f Cargo.toml ]; then
+            echo "has_cargo=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_cargo=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bootstrap check
+        if: steps.project.outputs.has_cargo != 'true'
+        run: echo "No Cargo.toml yet; skipping Rust checks on the bootstrap branch."
+
+      - name: Cache cargo registry
+        if: steps.project.outputs.has_cargo == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-
+
+      - name: Install Rust toolchain
+        if: steps.project.outputs.has_cargo == 'true'
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt --component clippy
+          rustup default stable
+
+      - name: Format check
+        if: steps.project.outputs.has_cargo == 'true'
+        run: cargo fmt --all --check
+
+      - name: Clippy
+        if: steps.project.outputs.has_cargo == 'true'
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Test
+        if: steps.project.outputs.has_cargo == 'true'
+        run: cargo test --all-targets
+
+      - name: Build release binary
+        if: steps.project.outputs.has_cargo == 'true'
+        run: cargo build --release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,138 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.runs-on }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            runs-on: ubuntu-latest
+            linker: musl-gcc
+          - target: aarch64-unknown-linux-musl
+            runs-on: ubuntu-24.04-arm
+            linker: musl-gcc
+          - target: x86_64-apple-darwin
+            runs-on: macos-13
+          - target: aarch64-apple-darwin
+            runs-on: macos-14
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup target add "${{ matrix.target }}" --toolchain stable
+
+      - name: Install musl tools
+        if: contains(matrix.target, 'musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Configure musl linker
+        if: contains(matrix.target, 'musl')
+        run: |
+          mkdir -p "$HOME/.cargo"
+          cat >> "$HOME/.cargo/config.toml" <<EOF
+          [target.${{ matrix.target }}]
+          linker = "${{ matrix.linker }}"
+          EOF
+
+      - name: Build release binary
+        env:
+          RUSTUP_TOOLCHAIN: stable
+        run: cargo build --release --target "${{ matrix.target }}"
+
+      - name: Package archive
+        run: |
+          set -euo pipefail
+          archive_name="glint-${{ matrix.target }}"
+          staging_dir="$RUNNER_TEMP/$archive_name"
+          mkdir -p "$staging_dir"
+          cp "target/${{ matrix.target }}/release/glint" "$staging_dir/"
+          cp LICENSE "$staging_dir/"
+          printf 'tag=%s\ncommit=%s\ntarget=%s\n' "${GITHUB_REF_NAME}" "${GITHUB_SHA}" "${{ matrix.target }}" > "$staging_dir/RELEASE-METADATA.txt"
+          tar -czf "$archive_name.tar.gz" -C "$RUNNER_TEMP" "$archive_name"
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$archive_name.tar.gz" > "$archive_name.tar.gz.sha256"
+          else
+            shasum -a 256 "$archive_name.tar.gz" > "$archive_name.tar.gz.sha256"
+          fi
+
+      - name: Upload archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: glint-${{ matrix.target }}
+          path: |
+            glint-${{ matrix.target }}.tar.gz
+            glint-${{ matrix.target }}.tar.gz.sha256
+          if-no-files-found: error
+
+  publish:
+    name: Publish prerelease
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: glint-*
+          merge-multiple: true
+
+      - name: Enforce immutable release tags
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release for ${TAG} already exists; version tags are immutable" >&2
+            exit 1
+          fi
+
+      - name: Publish GitHub prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          assets=(dist/*.tar.gz dist/*.tar.gz.sha256)
+          if [ "${#assets[@]}" -eq 0 ]; then
+            echo "no release assets found" >&2
+            exit 1
+          fi
+
+          notes_file="$RUNNER_TEMP/release-notes.md"
+          cat > "$notes_file" <<EOF
+          glint ${TAG}
+
+          Prerelease artifacts for ${TAG}.
+          EOF
+
+          gh release create "$TAG" "${assets[@]}" \
+            --title "$TAG" \
+            --prerelease \
+            --notes-file "$notes_file"

--- a/docs/doctrine.md
+++ b/docs/doctrine.md
@@ -1,0 +1,42 @@
+# Glint Doctrine
+
+## Workflow
+
+- Use trunk-based development.
+- `main` is trunk.
+- Use Graphite (`gt`) for stacked branches and PRs.
+- Keep each branch focused on one reviewable concern.
+- Prefer `gt c -am "message"` after making changes.
+- Use `gt m -a` for follow-up edits on the current branch.
+- Use `gt restack` when stack relationships change.
+- Submit reviewable slices early with `gt ss`.
+
+## Solo Maintainer Policy
+
+- The repo currently relies on workflow discipline rather than branch protection.
+- Merge only after the PR is green locally and in GitHub Actions.
+- Use Graphite stacks to keep changes small and auditable even without required approvals.
+- Treat tags as immutable release identifiers.
+- Never move or reuse a published version tag. Cut a new version instead.
+
+## Release Discipline
+
+- The first release target is `0.1.0-alpha.1`.
+- Treat prerelease tags as real shipping milestones, not placeholders.
+- Keep release notes aligned with the actual shipped behavior.
+- Do not describe installable behavior in the README before the binary exists.
+
+## Testing Expectations
+
+- Treat prompt output as the contract.
+- Prefer executable specs and golden tests for user-visible behavior.
+- Add fixtures for representative Git states before widening implementation.
+- Use unit tests for pure parsing and rendering logic.
+- Use integration tests for the CLI boundary.
+
+## Design Rules
+
+- Keep the functional core pure where practical.
+- Push filesystem, process, and Git I/O to the edges.
+- Keep docs short and honest about current state.
+- Add new docs only when they protect correctness, reviewability, or onboarding.


### PR DESCRIPTION
## Summary
Add bootstrap-safe CI, immutable tag-based prerelease automation, and the solo-maintainer workflow policy.

## Why
This stack needs CI and release plumbing to land before the crate and tests above it. The workflow also needs to pass on top of current `main`, which does not contain a Rust workspace yet.

## What Changed
- added a bootstrap-safe `CI` GitHub Actions workflow that skips Rust steps until `Cargo.toml` exists
- added a tag-driven prerelease workflow that treats version tags as immutable and refuses to overwrite an existing release
- documented the solo-maintainer merge discipline and immutable tag policy in `docs/doctrine.md`

## Stack Context
Base branch: `main`

Current branch: `03-21-add_ci_and_release_automation`

This is the bottom branch in the stack. Merge this first so the branches above it inherit live CI/CD from trunk.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/release.yml")'`
- GitHub Actions: `CI / fmt, clippy, test, build`

## Risk
This branch intentionally installs automation before the Rust crate exists on `main`, so the CI workflow uses a bootstrap check and only runs Rust commands once a workspace is present.

## Follow-Ups
- Merge this first.
- Restack the remaining PRs onto `main` after merge so they target trunk directly.
