### PR TITLE
Add compatibility fixture harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,8 @@ name = "glint"
 version = "0.1.0-alpha.1"
 dependencies = [
  "assert_cmd",
+ "serde",
+ "serde_json",
  "tempfile",
 ]
 
@@ -281,6 +283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,6 @@ description = "Fast, minimal Git-aware prompt status as a single binary."
 
 [dev-dependencies]
 assert_cmd = "2.0.17"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 tempfile = "3.23.0"

--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ Fast, minimal Git-aware prompt status as a single binary.
 `glint` is the Rust replacement for `zsh-git-prompt`'s
 `git_super_status` prompt segment.
 
-Current state: the foundation-stage crate and binary are in place. Local source
-installs work today; GitHub Release artifacts remain alpha-stage follow-up
-work.
+Current state: the crate and CLI are in place, source installs work, and the
+compatibility surface is still being built out for the first alpha.
 
 ---
 
@@ -38,19 +37,20 @@ The first shipped version target is `0.1.0-alpha.1`.
 
 ## Install
 
-Local source install is available now:
+Source installs work today:
 
 ```bash
 cargo install --path .
 ```
 
-GitHub Release artifacts are planned once the first alpha is tagged.
+Tagged release artifacts are not published yet. Those will land through GitHub
+Releases once the first alpha is tagged.
 
 ---
 
 ## Usage
 
-Shell integration target:
+The intended shell integration is:
 
 ```zsh
 $(git_super_status)
@@ -62,8 +62,8 @@ with:
 $(glint)
 ```
 
-The contract and output coverage are still being tightened as the alpha stack
-lands, but the binary already emits the prompt segment shape described here.
+That command already runs locally from the crate in this repo. The remaining
+work is narrowing the output toward the compatibility contract.
 
 ---
 

--- a/compat/Dockerfile
+++ b/compat/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:24.04
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        python3 \
+        python3-venv \
+        zsh \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work

--- a/compat/README.md
+++ b/compat/README.md
@@ -1,0 +1,52 @@
+# Compatibility Harness
+
+This directory holds the upstream-compatibility workflow for `glint`.
+
+## Goals
+
+- Capture observed `zsh-git-prompt` behavior in a clean environment.
+- Store the captured behavior as machine-readable fixtures.
+- Verify `glint` against those fixtures in normal local and CI test runs.
+- Keep `glint` implementation independent from upstream shell code once the
+  behavioral contract is captured.
+
+## Split
+
+- `compat/generate-upstream-fixtures.sh`
+  - Containerized, expensive, updates fixture files from upstream behavior.
+- `cargo test --test compat_fixtures`
+  - Cheap, local, runs `glint` against checked-in fixtures.
+
+## Fixture Format
+
+Fixtures live in `compat/fixtures/*.json`.
+
+Each file contains:
+
+- metadata about the upstream ref and generator run
+- ordered setup operations for synthetic repos
+- theme/env overrides
+- expected stdout for `glint`
+
+The verifier treats fixture files as the contract surface. The generator is
+allowed to update them. Normal CI should only verify them.
+
+This keeps the workflow spec-first:
+
+- observe upstream behavior
+- review and accept the fixture diff as contract
+- implement `glint` natively in Rust against that contract
+
+## Generator Workflow
+
+1. Build the container from `compat/Dockerfile`.
+2. Clone the pinned upstream repo inside the container.
+3. Create synthetic repos for each compatibility case.
+4. Invoke upstream `git_super_status` under controlled theme variables.
+5. Write JSON fixtures into `compat/fixtures/`.
+
+## Review Rule
+
+Generated fixture changes are not automatically accepted as product truth.
+Review the diff and decide whether a changed upstream behavior belongs in the
+`glint` compatibility contract before updating implementation or specs.

--- a/compat/capture_upstream.py
+++ b/compat/capture_upstream.py
@@ -89,7 +89,7 @@ def clone_remote(remote: Path, repo: Path):
     git(repo, "config", "user.email", "glint-compat@example.com")
 
 
-def upstream_output(repo: Path, upstream_root: Path) -> str:
+def upstream_output(repo: Path, upstream_root: Path, env_overrides=None) -> str:
     script_path = upstream_root / UPSTREAM_SCRIPT
     if not script_path.exists():
         raise RuntimeError(
@@ -99,24 +99,40 @@ def upstream_output(repo: Path, upstream_root: Path) -> str:
 
     env = os.environ.copy()
     env.update(THEME)
+    if env_overrides:
+        env.update(env_overrides)
     cmd = [
         "zsh",
         "-lc",
         f"source {script_path} >/dev/null 2>&1 && git_super_status",
     ]
     result = run(cmd, cwd=repo, env=env)
-    return result.stdout.strip()
+    return result.stdout.rstrip("\n")
+
+
+def git_output(repo: Path, *args: str) -> str:
+    return git(repo, *args).stdout.strip()
 
 
 def build_cases(upstream_root: Path):
     cases = []
 
     with tempfile.TemporaryDirectory() as tmp:
-        ctx = Context(Path(tmp))
+        tmp_root = Path(tmp)
 
-        repo = ctx.repo("repo")
-        init_repo(repo)
-        commit_file(repo, "tracked.txt", "hello", "Initial commit")
+        def case_context(name: str) -> Context:
+            root = tmp_root / name
+            root.mkdir(parents=True, exist_ok=True)
+            return Context(root)
+
+        def seeded_repo(ctx: Context) -> Path:
+            repo = ctx.repo("repo")
+            init_repo(repo)
+            commit_file(repo, "tracked.txt", "hello", "Initial commit")
+            return repo
+
+        ctx = case_context("clean_branch")
+        repo = seeded_repo(ctx)
         cases.append(
             {
                 "name": "clean_branch",
@@ -134,29 +150,356 @@ def build_cases(upstream_root: Path):
             }
         )
 
-        repo = ctx.repo("changed")
-        init_repo(repo)
-        commit_file(repo, "tracked.txt", "hello", "Initial commit")
+        ctx = case_context("staged_only")
+        repo = seeded_repo(ctx)
         write_file(repo, "tracked.txt", "updated")
+        git(repo, "add", "tracked.txt")
         cases.append(
             {
-                "name": "changed_only",
-                "target_repo": "changed",
+                "name": "staged_only",
                 "expected_stdout": upstream_output(repo, upstream_root),
                 "operations": [
-                    {"type": "init_repo", "repo": "changed"},
+                    {"type": "init_repo", "repo": "repo"},
                     {
                         "type": "commit_file",
-                        "repo": "changed",
+                        "repo": "repo",
                         "path": "tracked.txt",
                         "contents": "hello",
                         "message": "Initial commit",
                     },
                     {
                         "type": "write_file",
-                        "repo": "changed",
+                        "repo": "repo",
                         "path": "tracked.txt",
                         "contents": "updated",
+                    },
+                    {"type": "git", "repo": "repo", "args": ["add", "tracked.txt"]},
+                ],
+            }
+        )
+
+        ctx = case_context("changed_only")
+        repo = seeded_repo(ctx)
+        write_file(repo, "tracked.txt", "updated")
+        cases.append(
+            {
+                "name": "changed_only",
+                "expected_stdout": upstream_output(repo, upstream_root),
+                "operations": [
+                    {"type": "init_repo", "repo": "repo"},
+                    {
+                        "type": "commit_file",
+                        "repo": "repo",
+                        "path": "tracked.txt",
+                        "contents": "hello",
+                        "message": "Initial commit",
+                    },
+                    {
+                        "type": "write_file",
+                        "repo": "repo",
+                        "path": "tracked.txt",
+                        "contents": "updated",
+                    },
+                ],
+            }
+        )
+
+        ctx = case_context("untracked")
+        repo = seeded_repo(ctx)
+        write_file(repo, "new.txt", "new")
+        cases.append(
+            {
+                "name": "untracked",
+                "expected_stdout": upstream_output(repo, upstream_root),
+                "operations": [
+                    {"type": "init_repo", "repo": "repo"},
+                    {
+                        "type": "commit_file",
+                        "repo": "repo",
+                        "path": "tracked.txt",
+                        "contents": "hello",
+                        "message": "Initial commit",
+                    },
+                    {
+                        "type": "write_file",
+                        "repo": "repo",
+                        "path": "new.txt",
+                        "contents": "new",
+                    },
+                ],
+            }
+        )
+
+        ctx = case_context("ahead_only")
+        repo = seeded_repo(ctx)
+        origin = ctx.repo("origin")
+        git(origin, "init", "--bare")
+        add_remote_and_push(repo, origin)
+        commit_file(repo, "tracked.txt", "local", "Local commit")
+        cases.append(
+            {
+                "name": "ahead_only",
+                "expected_stdout": upstream_output(repo, upstream_root),
+                "operations": [
+                    {"type": "bare_remote", "repo": "origin"},
+                    {"type": "init_repo", "repo": "repo"},
+                    {
+                        "type": "commit_file",
+                        "repo": "repo",
+                        "path": "tracked.txt",
+                        "contents": "hello",
+                        "message": "Initial commit",
+                    },
+                    {
+                        "type": "add_remote_and_push",
+                        "repo": "repo",
+                        "remote": "origin",
+                    },
+                    {
+                        "type": "commit_file",
+                        "repo": "repo",
+                        "path": "tracked.txt",
+                        "contents": "local",
+                        "message": "Local commit",
+                    },
+                ],
+            }
+        )
+
+        ctx = case_context("behind_only")
+        repo = seeded_repo(ctx)
+        origin = ctx.repo("origin")
+        peer = ctx.repo("peer")
+        git(origin, "init", "--bare")
+        add_remote_and_push(repo, origin)
+        clone_remote(origin, peer)
+        commit_file(peer, "peer.txt", "peer", "Peer commit")
+        git(peer, "push", "origin", "main")
+        git(repo, "fetch", "origin")
+        cases.append(
+            {
+                "name": "behind_only",
+                "expected_stdout": upstream_output(repo, upstream_root),
+                "operations": [
+                    {"type": "bare_remote", "repo": "origin"},
+                    {"type": "init_repo", "repo": "repo"},
+                    {
+                        "type": "commit_file",
+                        "repo": "repo",
+                        "path": "tracked.txt",
+                        "contents": "hello",
+                        "message": "Initial commit",
+                    },
+                    {
+                        "type": "add_remote_and_push",
+                        "repo": "repo",
+                        "remote": "origin",
+                    },
+                    {
+                        "type": "clone_remote",
+                        "repo": "peer",
+                        "remote": "origin",
+                    },
+                    {
+                        "type": "commit_file",
+                        "repo": "peer",
+                        "path": "peer.txt",
+                        "contents": "peer",
+                        "message": "Peer commit",
+                    },
+                    {"type": "git", "repo": "peer", "args": ["push", "origin", "main"]},
+                    {"type": "git", "repo": "repo", "args": ["fetch", "origin"]},
+                ],
+            }
+        )
+
+        ctx = case_context("diverged")
+        repo = seeded_repo(ctx)
+        origin = ctx.repo("origin")
+        peer = ctx.repo("peer")
+        git(origin, "init", "--bare")
+        add_remote_and_push(repo, origin)
+        clone_remote(origin, peer)
+        commit_file(peer, "peer.txt", "peer", "Peer commit")
+        git(peer, "push", "origin", "main")
+        commit_file(repo, "local.txt", "local", "Local commit")
+        git(repo, "fetch", "origin")
+        cases.append(
+            {
+                "name": "diverged",
+                "expected_stdout": upstream_output(repo, upstream_root),
+                "operations": [
+                    {"type": "bare_remote", "repo": "origin"},
+                    {"type": "init_repo", "repo": "repo"},
+                    {
+                        "type": "commit_file",
+                        "repo": "repo",
+                        "path": "tracked.txt",
+                        "contents": "hello",
+                        "message": "Initial commit",
+                    },
+                    {
+                        "type": "add_remote_and_push",
+                        "repo": "repo",
+                        "remote": "origin",
+                    },
+                    {
+                        "type": "clone_remote",
+                        "repo": "peer",
+                        "remote": "origin",
+                    },
+                    {
+                        "type": "commit_file",
+                        "repo": "peer",
+                        "path": "peer.txt",
+                        "contents": "peer",
+                        "message": "Peer commit",
+                    },
+                    {"type": "git", "repo": "peer", "args": ["push", "origin", "main"]},
+                    {
+                        "type": "commit_file",
+                        "repo": "repo",
+                        "path": "local.txt",
+                        "contents": "local",
+                        "message": "Local commit",
+                    },
+                    {"type": "git", "repo": "repo", "args": ["fetch", "origin"]},
+                ],
+            }
+        )
+
+        ctx = case_context("conflicts_and_changed")
+        repo = seeded_repo(ctx)
+        git(repo, "checkout", "-b", "feature")
+        write_file(repo, "tracked.txt", "feature")
+        git(repo, "add", "tracked.txt")
+        git(repo, "commit", "-m", "Feature change")
+        git(repo, "checkout", "main")
+        commit_file(repo, "other.txt", "base", "Add second file")
+        write_file(repo, "tracked.txt", "main")
+        git(repo, "add", "tracked.txt")
+        git(repo, "commit", "-m", "Main change")
+        merge_result = git(repo, "merge", "feature", check=False)
+        if merge_result.returncode == 0:
+            raise RuntimeError("expected merge conflict when capturing conflicts_and_changed")
+        write_file(repo, "other.txt", "changed")
+        cases.append(
+            {
+                "name": "conflicts_and_changed",
+                "expected_stdout": upstream_output(repo, upstream_root),
+                "operations": [
+                    {"type": "init_repo", "repo": "repo"},
+                    {
+                        "type": "commit_file",
+                        "repo": "repo",
+                        "path": "tracked.txt",
+                        "contents": "hello",
+                        "message": "Initial commit",
+                    },
+                    {"type": "git", "repo": "repo", "args": ["checkout", "-b", "feature"]},
+                    {
+                        "type": "write_file",
+                        "repo": "repo",
+                        "path": "tracked.txt",
+                        "contents": "feature",
+                    },
+                    {"type": "git", "repo": "repo", "args": ["add", "tracked.txt"]},
+                    {
+                        "type": "git",
+                        "repo": "repo",
+                        "args": ["commit", "-m", "Feature change"],
+                    },
+                    {"type": "git", "repo": "repo", "args": ["checkout", "main"]},
+                    {
+                        "type": "commit_file",
+                        "repo": "repo",
+                        "path": "other.txt",
+                        "contents": "base",
+                        "message": "Add second file",
+                    },
+                    {
+                        "type": "write_file",
+                        "repo": "repo",
+                        "path": "tracked.txt",
+                        "contents": "main",
+                    },
+                    {"type": "git", "repo": "repo", "args": ["add", "tracked.txt"]},
+                    {
+                        "type": "git",
+                        "repo": "repo",
+                        "args": ["commit", "-m", "Main change"],
+                    },
+                    {
+                        "type": "git",
+                        "repo": "repo",
+                        "args": ["merge", "feature"],
+                        "expect_success": False,
+                    },
+                    {
+                        "type": "write_file",
+                        "repo": "repo",
+                        "path": "other.txt",
+                        "contents": "changed",
+                    },
+                ],
+            }
+        )
+
+        ctx = case_context("detached_head_abbrev")
+        repo = seeded_repo(ctx)
+        git(repo, "config", "core.abbrev", "12")
+        git(repo, "checkout", "--detach")
+        short_head = git_output(repo, "rev-parse", "--short", "HEAD")
+        expected_stdout = upstream_output(repo, upstream_root).replace(
+            f":{short_head}",
+            ":{{git_short_head:repo}}",
+            1,
+        )
+        cases.append(
+            {
+                "name": "detached_head_abbrev",
+                "expected_stdout": expected_stdout,
+                "operations": [
+                    {"type": "init_repo", "repo": "repo"},
+                    {
+                        "type": "commit_file",
+                        "repo": "repo",
+                        "path": "tracked.txt",
+                        "contents": "hello",
+                        "message": "Initial commit",
+                    },
+                    {
+                        "type": "git",
+                        "repo": "repo",
+                        "args": ["config", "core.abbrev", "12"],
+                    },
+                    {"type": "git", "repo": "repo", "args": ["checkout", "--detach"]},
+                ],
+            }
+        )
+
+        ctx = case_context("theme_overrides")
+        repo = seeded_repo(ctx)
+        env = {
+            "ZSH_THEME_GIT_PROMPT_PREFIX": "[",
+            "ZSH_THEME_GIT_PROMPT_SUFFIX": "]",
+            "ZSH_THEME_GIT_PROMPT_SEPARATOR": " :: ",
+            "ZSH_THEME_GIT_PROMPT_BRANCH": "BR:",
+            "ZSH_THEME_GIT_PROMPT_CLEAN": "OK",
+        }
+        cases.append(
+            {
+                "name": "theme_overrides",
+                "expected_stdout": upstream_output(repo, upstream_root, env),
+                "env": env,
+                "operations": [
+                    {"type": "init_repo", "repo": "repo"},
+                    {
+                        "type": "commit_file",
+                        "repo": "repo",
+                        "path": "tracked.txt",
+                        "contents": "hello",
+                        "message": "Initial commit",
                     },
                 ],
             }

--- a/compat/capture_upstream.py
+++ b/compat/capture_upstream.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+UPSTREAM_REPO = os.environ["UPSTREAM_REPO"]
+UPSTREAM_REF = os.environ["UPSTREAM_REF"]
+UPSTREAM_SCRIPT = os.environ["UPSTREAM_SCRIPT"]
+REPO_ROOT = Path("/work")
+FIXTURE_PATH = REPO_ROOT / "compat" / "fixtures" / "zsh-git-prompt-common-path.generated.json"
+
+THEME = {
+    "ZSH_THEME_GIT_PROMPT_PREFIX": "(",
+    "ZSH_THEME_GIT_PROMPT_SUFFIX": ")",
+    "ZSH_THEME_GIT_PROMPT_SEPARATOR": "|",
+    "ZSH_THEME_GIT_PROMPT_BRANCH": "",
+    "ZSH_THEME_GIT_PROMPT_STAGED": "●",
+    "ZSH_THEME_GIT_PROMPT_CONFLICTS": "✖",
+    "ZSH_THEME_GIT_PROMPT_CHANGED": "✚",
+    "ZSH_THEME_GIT_PROMPT_BEHIND": "↓",
+    "ZSH_THEME_GIT_PROMPT_AHEAD": "↑",
+    "ZSH_THEME_GIT_PROMPT_UNTRACKED": "…",
+    "ZSH_THEME_GIT_PROMPT_CLEAN": "✔",
+}
+
+
+@dataclass
+class Context:
+    root: Path
+
+    def repo(self, name: str) -> Path:
+        path = self.root / name
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+
+def run(cmd, cwd=None, env=None, check=True):
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise RuntimeError(
+            f"command failed: {cmd}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def git(repo: Path, *args: str, check=True):
+    return run(["git", *args], cwd=repo, check=check)
+
+
+def write_file(repo: Path, relative_path: str, contents: str):
+    path = repo / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)
+
+
+def init_repo(repo: Path):
+    git(repo, "init", "-b", "main")
+    git(repo, "config", "user.name", "glint-compat")
+    git(repo, "config", "user.email", "glint-compat@example.com")
+
+
+def commit_file(repo: Path, relative_path: str, contents: str, message: str):
+    write_file(repo, relative_path, contents)
+    git(repo, "add", relative_path)
+    git(repo, "commit", "-m", message)
+
+
+def add_remote_and_push(repo: Path, remote: Path):
+    git(repo, "remote", "add", "origin", str(remote))
+    git(repo, "push", "-u", "origin", "main")
+
+
+def clone_remote(remote: Path, repo: Path):
+    shutil.rmtree(repo)
+    run(["git", "clone", "--branch", "main", str(remote), str(repo)])
+    git(repo, "config", "user.name", "glint-compat")
+    git(repo, "config", "user.email", "glint-compat@example.com")
+
+
+def upstream_output(repo: Path, upstream_root: Path) -> str:
+    script_path = upstream_root / UPSTREAM_SCRIPT
+    if not script_path.exists():
+        raise RuntimeError(
+            f"upstream prompt script not found at {script_path}. "
+            "Set UPSTREAM_SCRIPT to the script that defines git_super_status."
+        )
+
+    env = os.environ.copy()
+    env.update(THEME)
+    cmd = [
+        "zsh",
+        "-lc",
+        f"source {script_path} >/dev/null 2>&1 && git_super_status",
+    ]
+    result = run(cmd, cwd=repo, env=env)
+    return result.stdout.strip()
+
+
+def build_cases(upstream_root: Path):
+    cases = []
+
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = Context(Path(tmp))
+
+        repo = ctx.repo("repo")
+        init_repo(repo)
+        commit_file(repo, "tracked.txt", "hello", "Initial commit")
+        cases.append(
+            {
+                "name": "clean_branch",
+                "expected_stdout": upstream_output(repo, upstream_root),
+                "operations": [
+                    {"type": "init_repo", "repo": "repo"},
+                    {
+                        "type": "commit_file",
+                        "repo": "repo",
+                        "path": "tracked.txt",
+                        "contents": "hello",
+                        "message": "Initial commit",
+                    },
+                ],
+            }
+        )
+
+        repo = ctx.repo("changed")
+        init_repo(repo)
+        commit_file(repo, "tracked.txt", "hello", "Initial commit")
+        write_file(repo, "tracked.txt", "updated")
+        cases.append(
+            {
+                "name": "changed_only",
+                "target_repo": "changed",
+                "expected_stdout": upstream_output(repo, upstream_root),
+                "operations": [
+                    {"type": "init_repo", "repo": "changed"},
+                    {
+                        "type": "commit_file",
+                        "repo": "changed",
+                        "path": "tracked.txt",
+                        "contents": "hello",
+                        "message": "Initial commit",
+                    },
+                    {
+                        "type": "write_file",
+                        "repo": "changed",
+                        "path": "tracked.txt",
+                        "contents": "updated",
+                    },
+                ],
+            }
+        )
+
+    return cases
+
+
+def main():
+    upstream_root = Path(tempfile.mkdtemp(prefix="zsh-git-prompt-"))
+    run(["git", "clone", UPSTREAM_REPO, str(upstream_root)])
+    run(["git", "checkout", UPSTREAM_REF], cwd=upstream_root)
+
+    fixture = {
+        "metadata": {
+            "source": "zsh-git-prompt",
+            "upstream_repo": UPSTREAM_REPO,
+            "upstream_ref": UPSTREAM_REF,
+            "upstream_script": UPSTREAM_SCRIPT,
+            "generator": "compat/capture_upstream.py",
+        },
+        "cases": build_cases(upstream_root),
+    }
+
+    FIXTURE_PATH.write_text(json.dumps(fixture, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/compat/fixtures/bootstrap-common-path.json
+++ b/compat/fixtures/bootstrap-common-path.json
@@ -259,6 +259,84 @@
       ]
     },
     {
+      "name": "conflicts_and_changed",
+      "expected_stdout": "(main|✖1✚1)",
+      "operations": [
+        {
+          "type": "init_repo",
+          "repo": "repo"
+        },
+        {
+          "type": "commit_file",
+          "repo": "repo",
+          "path": "tracked.txt",
+          "contents": "hello",
+          "message": "Initial commit"
+        },
+        {
+          "type": "git",
+          "repo": "repo",
+          "args": ["checkout", "-b", "feature"]
+        },
+        {
+          "type": "write_file",
+          "repo": "repo",
+          "path": "tracked.txt",
+          "contents": "feature"
+        },
+        {
+          "type": "git",
+          "repo": "repo",
+          "args": ["add", "tracked.txt"]
+        },
+        {
+          "type": "git",
+          "repo": "repo",
+          "args": ["commit", "-m", "Feature change"]
+        },
+        {
+          "type": "git",
+          "repo": "repo",
+          "args": ["checkout", "main"]
+        },
+        {
+          "type": "commit_file",
+          "repo": "repo",
+          "path": "other.txt",
+          "contents": "base",
+          "message": "Add second file"
+        },
+        {
+          "type": "write_file",
+          "repo": "repo",
+          "path": "tracked.txt",
+          "contents": "main"
+        },
+        {
+          "type": "git",
+          "repo": "repo",
+          "args": ["add", "tracked.txt"]
+        },
+        {
+          "type": "git",
+          "repo": "repo",
+          "args": ["commit", "-m", "Main change"]
+        },
+        {
+          "type": "git",
+          "repo": "repo",
+          "args": ["merge", "feature"],
+          "expect_success": false
+        },
+        {
+          "type": "write_file",
+          "repo": "repo",
+          "path": "other.txt",
+          "contents": "changed"
+        }
+      ]
+    },
+    {
       "name": "theme_overrides",
       "expected_stdout": "[BR:main :: OK]",
       "env": {

--- a/compat/fixtures/bootstrap-common-path.json
+++ b/compat/fixtures/bootstrap-common-path.json
@@ -1,0 +1,286 @@
+{
+  "metadata": {
+    "source": "bootstrap",
+    "note": "Seed fixtures for the compatibility harness. Replace or extend with generated upstream captures."
+  },
+  "cases": [
+    {
+      "name": "clean_branch",
+      "expected_stdout": "(main|✔)",
+      "operations": [
+        {
+          "type": "init_repo",
+          "repo": "repo"
+        },
+        {
+          "type": "commit_file",
+          "repo": "repo",
+          "path": "tracked.txt",
+          "contents": "hello",
+          "message": "Initial commit"
+        }
+      ]
+    },
+    {
+      "name": "staged_only",
+      "expected_stdout": "(main|●1)",
+      "operations": [
+        {
+          "type": "init_repo",
+          "repo": "repo"
+        },
+        {
+          "type": "commit_file",
+          "repo": "repo",
+          "path": "tracked.txt",
+          "contents": "hello",
+          "message": "Initial commit"
+        },
+        {
+          "type": "write_file",
+          "repo": "repo",
+          "path": "tracked.txt",
+          "contents": "updated"
+        },
+        {
+          "type": "git",
+          "repo": "repo",
+          "args": ["add", "tracked.txt"]
+        }
+      ]
+    },
+    {
+      "name": "changed_only",
+      "expected_stdout": "(main|✚1)",
+      "operations": [
+        {
+          "type": "init_repo",
+          "repo": "repo"
+        },
+        {
+          "type": "commit_file",
+          "repo": "repo",
+          "path": "tracked.txt",
+          "contents": "hello",
+          "message": "Initial commit"
+        },
+        {
+          "type": "write_file",
+          "repo": "repo",
+          "path": "tracked.txt",
+          "contents": "updated"
+        }
+      ]
+    },
+    {
+      "name": "untracked",
+      "expected_stdout": "(main|…)",
+      "operations": [
+        {
+          "type": "init_repo",
+          "repo": "repo"
+        },
+        {
+          "type": "commit_file",
+          "repo": "repo",
+          "path": "tracked.txt",
+          "contents": "hello",
+          "message": "Initial commit"
+        },
+        {
+          "type": "write_file",
+          "repo": "repo",
+          "path": "new.txt",
+          "contents": "new"
+        }
+      ]
+    },
+    {
+      "name": "ahead_only",
+      "expected_stdout": "(main↑1|✔)",
+      "operations": [
+        {
+          "type": "bare_remote",
+          "repo": "origin"
+        },
+        {
+          "type": "init_repo",
+          "repo": "repo"
+        },
+        {
+          "type": "commit_file",
+          "repo": "repo",
+          "path": "tracked.txt",
+          "contents": "hello",
+          "message": "Initial commit"
+        },
+        {
+          "type": "add_remote_and_push",
+          "repo": "repo",
+          "remote": "origin"
+        },
+        {
+          "type": "commit_file",
+          "repo": "repo",
+          "path": "tracked.txt",
+          "contents": "local",
+          "message": "Local commit"
+        }
+      ]
+    },
+    {
+      "name": "behind_only",
+      "expected_stdout": "(main↓1|✔)",
+      "operations": [
+        {
+          "type": "bare_remote",
+          "repo": "origin"
+        },
+        {
+          "type": "init_repo",
+          "repo": "repo"
+        },
+        {
+          "type": "commit_file",
+          "repo": "repo",
+          "path": "tracked.txt",
+          "contents": "hello",
+          "message": "Initial commit"
+        },
+        {
+          "type": "add_remote_and_push",
+          "repo": "repo",
+          "remote": "origin"
+        },
+        {
+          "type": "clone_remote",
+          "repo": "peer",
+          "remote": "origin"
+        },
+        {
+          "type": "commit_file",
+          "repo": "peer",
+          "path": "peer.txt",
+          "contents": "peer",
+          "message": "Peer commit"
+        },
+        {
+          "type": "git",
+          "repo": "peer",
+          "args": ["push", "origin", "main"]
+        },
+        {
+          "type": "git",
+          "repo": "repo",
+          "args": ["fetch", "origin"]
+        }
+      ]
+    },
+    {
+      "name": "diverged",
+      "expected_stdout": "(main↓1↑1|✔)",
+      "operations": [
+        {
+          "type": "bare_remote",
+          "repo": "origin"
+        },
+        {
+          "type": "init_repo",
+          "repo": "repo"
+        },
+        {
+          "type": "commit_file",
+          "repo": "repo",
+          "path": "tracked.txt",
+          "contents": "hello",
+          "message": "Initial commit"
+        },
+        {
+          "type": "add_remote_and_push",
+          "repo": "repo",
+          "remote": "origin"
+        },
+        {
+          "type": "clone_remote",
+          "repo": "peer",
+          "remote": "origin"
+        },
+        {
+          "type": "commit_file",
+          "repo": "peer",
+          "path": "peer.txt",
+          "contents": "peer",
+          "message": "Peer commit"
+        },
+        {
+          "type": "git",
+          "repo": "peer",
+          "args": ["push", "origin", "main"]
+        },
+        {
+          "type": "commit_file",
+          "repo": "repo",
+          "path": "local.txt",
+          "contents": "local",
+          "message": "Local commit"
+        },
+        {
+          "type": "git",
+          "repo": "repo",
+          "args": ["fetch", "origin"]
+        }
+      ]
+    },
+    {
+      "name": "detached_head_abbrev",
+      "expected_stdout": "(:{{git_short_head:repo}}|✔)",
+      "operations": [
+        {
+          "type": "init_repo",
+          "repo": "repo"
+        },
+        {
+          "type": "commit_file",
+          "repo": "repo",
+          "path": "tracked.txt",
+          "contents": "hello",
+          "message": "Initial commit"
+        },
+        {
+          "type": "git",
+          "repo": "repo",
+          "args": ["config", "core.abbrev", "12"]
+        },
+        {
+          "type": "git",
+          "repo": "repo",
+          "args": ["checkout", "--detach"]
+        }
+      ]
+    },
+    {
+      "name": "theme_overrides",
+      "expected_stdout": "[BR:main :: OK]",
+      "env": {
+        "ZSH_THEME_GIT_PROMPT_PREFIX": "[",
+        "ZSH_THEME_GIT_PROMPT_SUFFIX": "]",
+        "ZSH_THEME_GIT_PROMPT_SEPARATOR": " :: ",
+        "ZSH_THEME_GIT_PROMPT_BRANCH": "BR:",
+        "ZSH_THEME_GIT_PROMPT_CLEAN": "OK"
+      },
+      "operations": [
+        {
+          "type": "init_repo",
+          "repo": "repo"
+        },
+        {
+          "type": "commit_file",
+          "repo": "repo",
+          "path": "tracked.txt",
+          "contents": "hello",
+          "message": "Initial commit"
+        }
+      ]
+    }
+  ]
+}

--- a/compat/generate-upstream-fixtures.sh
+++ b/compat/generate-upstream-fixtures.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+UPSTREAM_REPO=${UPSTREAM_REPO:-https://github.com/olivierverdier/zsh-git-prompt.git}
+UPSTREAM_REF=${UPSTREAM_REF:-master}
+UPSTREAM_SCRIPT=${UPSTREAM_SCRIPT:-gitprompt.sh}
+IMAGE_TAG=${IMAGE_TAG:-glint-compat-harness}
+
+docker build -f "$SCRIPT_DIR/Dockerfile" -t "$IMAGE_TAG" "$REPO_ROOT"
+
+docker run --rm \
+  -e UPSTREAM_REPO="$UPSTREAM_REPO" \
+  -e UPSTREAM_REF="$UPSTREAM_REF" \
+  -e UPSTREAM_SCRIPT="$UPSTREAM_SCRIPT" \
+  -v "$REPO_ROOT:/work" \
+  "$IMAGE_TAG" \
+  python3 /work/compat/capture_upstream.py

--- a/docs/doctrine.md
+++ b/docs/doctrine.md
@@ -42,6 +42,8 @@
 ## Testing Expectations
 
 - Treat prompt output as the contract.
+- Prefer capturing compatibility behavior as executable fixtures before widening
+  implementation.
 - Prefer executable specs and golden tests for user-visible behavior.
 - Add fixtures for representative Git states before widening implementation.
 - Use unit tests for pure parsing and rendering logic.

--- a/docs/spec/git-super-status.md
+++ b/docs/spec/git-super-status.md
@@ -4,6 +4,10 @@
 
 This document defines the first alpha compatibility target for `glint`.
 
+The executable fixture surface for that target lives under `compat/fixtures/`.
+Those fixtures are the machine-readable contract used by the compatibility
+verifier.
+
 ## Output Shape
 
 `glint` should emit a single prompt segment shaped like:
@@ -54,3 +58,9 @@ This document defines the first alpha compatibility target for `glint`.
 - Persistent config files
 - Advanced formatting flags
 - Full parity for rare upstream edge cases
+
+## Fixture Workflow
+
+- Use generated upstream fixtures to propose contract updates.
+- Review generated diffs before adopting them as `glint` behavior.
+- Keep normal CI on fixture verification, not on containerized upstream capture.

--- a/tests/compat_fixtures.rs
+++ b/tests/compat_fixtures.rs
@@ -51,6 +51,8 @@ enum Operation {
     Git {
         repo: String,
         args: Vec<String>,
+        #[serde(default = "default_expect_success")]
+        expect_success: bool,
     },
     AddRemoteAndPush {
         repo: String,
@@ -93,11 +95,12 @@ impl FixtureContext {
         match operation {
             Operation::InitRepo { repo } => {
                 let dir = self.ensure_repo(&repo);
-                git(dir.path(), ["init", "-b", "main"]);
-                git(dir.path(), ["config", "user.name", "glint-tests"]);
+                git(dir.path(), ["init", "-b", "main"], true);
+                git(dir.path(), ["config", "user.name", "glint-tests"], true);
                 git(
                     dir.path(),
                     ["config", "user.email", "glint-tests@example.com"],
+                    true,
                 );
             }
             Operation::BareRemote { repo } => {
@@ -114,10 +117,11 @@ impl FixtureContext {
                     remote_path.to_str().unwrap(),
                     dir.path().to_str().unwrap(),
                 ]);
-                git(dir.path(), ["config", "user.name", "glint-tests"]);
+                git(dir.path(), ["config", "user.name", "glint-tests"], true);
                 git(
                     dir.path(),
                     ["config", "user.email", "glint-tests@example.com"],
+                    true,
                 );
             }
             Operation::CommitFile {
@@ -128,8 +132,8 @@ impl FixtureContext {
             } => {
                 let repo_path = self.repo(&repo).to_path_buf();
                 write_file(&repo_path, &path, &contents);
-                git(&repo_path, ["add", path.as_str()]);
-                git(&repo_path, ["commit", "-m", message.as_str()]);
+                git(&repo_path, ["add", path.as_str()], true);
+                git(&repo_path, ["commit", "-m", message.as_str()], true);
             }
             Operation::WriteFile {
                 repo,
@@ -139,9 +143,13 @@ impl FixtureContext {
                 let repo_path = self.repo(&repo).to_path_buf();
                 write_file(&repo_path, &path, &contents);
             }
-            Operation::Git { repo, args } => {
+            Operation::Git {
+                repo,
+                args,
+                expect_success,
+            } => {
                 let repo_path = self.repo(&repo).to_path_buf();
-                git(&repo_path, args.iter().map(String::as_str));
+                git(&repo_path, args.iter().map(String::as_str), expect_success);
             }
             Operation::AddRemoteAndPush { repo, remote } => {
                 let repo_path = self.repo(&repo).to_path_buf();
@@ -149,8 +157,9 @@ impl FixtureContext {
                 git(
                     &repo_path,
                     ["remote", "add", "origin", remote_path.to_str().unwrap()],
+                    true,
                 );
-                git(&repo_path, ["push", "-u", "origin", "main"]);
+                git(&repo_path, ["push", "-u", "origin", "main"], true);
             }
         }
     }
@@ -168,6 +177,10 @@ impl FixtureContext {
 
 fn default_repo() -> String {
     "repo".to_owned()
+}
+
+fn default_expect_success() -> bool {
+    true
 }
 
 fn fixture_files() -> Vec<PathBuf> {
@@ -233,14 +246,14 @@ fn write_file(repo: &Path, path: &str, contents: &str) {
     fs::write(full_path, contents).unwrap();
 }
 
-fn git(repo: &Path, args: impl IntoIterator<Item = impl AsRef<str>>) {
+fn git(repo: &Path, args: impl IntoIterator<Item = impl AsRef<str>>, expect_success: bool) {
     let status = Command::new("git")
         .current_dir(repo)
         .args(args.into_iter().map(|arg| arg.as_ref().to_owned()))
         .status()
         .expect("git command should run");
 
-    assert!(status.success());
+    assert_eq!(status.success(), expect_success);
 }
 
 fn git_raw(args: impl IntoIterator<Item = impl AsRef<str>>) {

--- a/tests/compat_fixtures.rs
+++ b/tests/compat_fixtures.rs
@@ -1,0 +1,264 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::Deserialize;
+use tempfile::TempDir;
+
+const RESET: &str = "%{${reset_color}%}";
+
+#[derive(Debug, Deserialize)]
+struct FixtureFile {
+    cases: Vec<FixtureCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureCase {
+    name: String,
+    expected_stdout: String,
+    #[serde(default = "default_repo")]
+    target_repo: String,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    operations: Vec<Operation>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum Operation {
+    InitRepo {
+        repo: String,
+    },
+    BareRemote {
+        repo: String,
+    },
+    CloneRemote {
+        repo: String,
+        remote: String,
+    },
+    CommitFile {
+        repo: String,
+        path: String,
+        contents: String,
+        message: String,
+    },
+    WriteFile {
+        repo: String,
+        path: String,
+        contents: String,
+    },
+    Git {
+        repo: String,
+        args: Vec<String>,
+    },
+    AddRemoteAndPush {
+        repo: String,
+        remote: String,
+    },
+}
+
+#[test]
+fn fixture_contract_matches_glint() {
+    for path in fixture_files() {
+        let contents = fs::read_to_string(&path).unwrap();
+        let fixture: FixtureFile = serde_json::from_str(&contents).unwrap();
+
+        for case in fixture.cases {
+            let mut ctx = FixtureContext::default();
+            for operation in case.operations {
+                ctx.apply(operation);
+            }
+
+            let output = glint_output(ctx.repo(&case.target_repo), &case.env);
+            let expected = render_expected(&case.expected_stdout, &ctx);
+            assert_eq!(
+                output,
+                expected,
+                "fixture {} in {}",
+                case.name,
+                path.display()
+            );
+        }
+    }
+}
+
+#[derive(Default)]
+struct FixtureContext {
+    repos: BTreeMap<String, TempDir>,
+}
+
+impl FixtureContext {
+    fn apply(&mut self, operation: Operation) {
+        match operation {
+            Operation::InitRepo { repo } => {
+                let dir = self.ensure_repo(&repo);
+                git(dir.path(), ["init", "-b", "main"]);
+                git(dir.path(), ["config", "user.name", "glint-tests"]);
+                git(
+                    dir.path(),
+                    ["config", "user.email", "glint-tests@example.com"],
+                );
+            }
+            Operation::BareRemote { repo } => {
+                let dir = self.ensure_repo(&repo);
+                git_raw(["init", "--bare", dir.path().to_str().unwrap()]);
+            }
+            Operation::CloneRemote { repo, remote } => {
+                let remote_path = self.repo(&remote).to_path_buf();
+                let dir = self.ensure_repo(&repo);
+                git_raw([
+                    "clone",
+                    "--branch",
+                    "main",
+                    remote_path.to_str().unwrap(),
+                    dir.path().to_str().unwrap(),
+                ]);
+                git(dir.path(), ["config", "user.name", "glint-tests"]);
+                git(
+                    dir.path(),
+                    ["config", "user.email", "glint-tests@example.com"],
+                );
+            }
+            Operation::CommitFile {
+                repo,
+                path,
+                contents,
+                message,
+            } => {
+                let repo_path = self.repo(&repo).to_path_buf();
+                write_file(&repo_path, &path, &contents);
+                git(&repo_path, ["add", path.as_str()]);
+                git(&repo_path, ["commit", "-m", message.as_str()]);
+            }
+            Operation::WriteFile {
+                repo,
+                path,
+                contents,
+            } => {
+                let repo_path = self.repo(&repo).to_path_buf();
+                write_file(&repo_path, &path, &contents);
+            }
+            Operation::Git { repo, args } => {
+                let repo_path = self.repo(&repo).to_path_buf();
+                git(&repo_path, args.iter().map(String::as_str));
+            }
+            Operation::AddRemoteAndPush { repo, remote } => {
+                let repo_path = self.repo(&repo).to_path_buf();
+                let remote_path = self.repo(&remote).to_path_buf();
+                git(
+                    &repo_path,
+                    ["remote", "add", "origin", remote_path.to_str().unwrap()],
+                );
+                git(&repo_path, ["push", "-u", "origin", "main"]);
+            }
+        }
+    }
+
+    fn ensure_repo(&mut self, name: &str) -> &TempDir {
+        self.repos
+            .entry(name.to_owned())
+            .or_insert_with(|| tempfile::tempdir().unwrap())
+    }
+
+    fn repo(&self, name: &str) -> &Path {
+        self.repos.get(name).unwrap().path()
+    }
+}
+
+fn default_repo() -> String {
+    "repo".to_owned()
+}
+
+fn fixture_files() -> Vec<PathBuf> {
+    let mut files = fs::read_dir("compat/fixtures")
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("json"))
+        .collect::<Vec<_>>();
+    files.sort();
+    files
+}
+
+fn glint_output(repo: &Path, env_overrides: &BTreeMap<String, String>) -> String {
+    let mut cmd = assert_cmd::Command::cargo_bin("glint").unwrap();
+    cmd.current_dir(repo);
+    cmd.env("ZSH_THEME_GIT_PROMPT_PREFIX", "(");
+    cmd.env("ZSH_THEME_GIT_PROMPT_SUFFIX", ")");
+    cmd.env("ZSH_THEME_GIT_PROMPT_SEPARATOR", "|");
+    cmd.env("ZSH_THEME_GIT_PROMPT_BRANCH", "");
+    cmd.env("ZSH_THEME_GIT_PROMPT_STAGED", "●");
+    cmd.env("ZSH_THEME_GIT_PROMPT_CONFLICTS", "✖");
+    cmd.env("ZSH_THEME_GIT_PROMPT_CHANGED", "✚");
+    cmd.env("ZSH_THEME_GIT_PROMPT_BEHIND", "↓");
+    cmd.env("ZSH_THEME_GIT_PROMPT_AHEAD", "↑");
+    cmd.env("ZSH_THEME_GIT_PROMPT_UNTRACKED", "…");
+    cmd.env("ZSH_THEME_GIT_PROMPT_CLEAN", "✔");
+
+    for (key, value) in env_overrides {
+        cmd.env(key, value);
+    }
+
+    let output = cmd.assert().success().get_output().stdout.clone();
+    normalize_output(String::from_utf8(output).unwrap())
+}
+
+fn normalize_output(output: String) -> String {
+    output.replace(RESET, "")
+}
+
+fn render_expected(template: &str, ctx: &FixtureContext) -> String {
+    let mut rendered = template.to_owned();
+
+    while let Some(start) = rendered.find("{{git_short_head:") {
+        let rest = &rendered[start..];
+        let end = rest.find("}}").unwrap();
+        let token = &rest[..end + 2];
+        let repo_name = token
+            .trim_start_matches("{{git_short_head:")
+            .trim_end_matches("}}");
+        let value = git_output(ctx.repo(repo_name), ["rev-parse", "--short", "HEAD"]);
+        rendered.replace_range(start..start + token.len(), value.trim());
+    }
+
+    rendered
+}
+
+fn write_file(repo: &Path, path: &str, contents: &str) {
+    let full_path = repo.join(path);
+    if let Some(parent) = full_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(full_path, contents).unwrap();
+}
+
+fn git(repo: &Path, args: impl IntoIterator<Item = impl AsRef<str>>) {
+    let status = Command::new("git")
+        .current_dir(repo)
+        .args(args.into_iter().map(|arg| arg.as_ref().to_owned()))
+        .status()
+        .expect("git command should run");
+
+    assert!(status.success());
+}
+
+fn git_raw(args: impl IntoIterator<Item = impl AsRef<str>>) {
+    let status = Command::new("git")
+        .args(args.into_iter().map(|arg| arg.as_ref().to_owned()))
+        .status()
+        .expect("git command should run");
+
+    assert!(status.success());
+}
+
+fn git_output(repo: &Path, args: impl IntoIterator<Item = impl AsRef<str>>) -> String {
+    let output = Command::new("git")
+        .current_dir(repo)
+        .args(args.into_iter().map(|arg| arg.as_ref().to_owned()))
+        .output()
+        .expect("git command should run");
+
+    assert!(output.status.success());
+    String::from_utf8(output.stdout).unwrap()
+}


### PR DESCRIPTION
## Summary
Add a compatibility fixture harness, seed fixtures, and upstream-capture tooling for reviewing `glint` against a machine-readable contract.

## Why
The alpha foundation and focused CLI integration coverage are already in place. This branch adds the broader workflow for capturing upstream behavior, checking in fixtures, and verifying `glint` against them in normal test runs.

## What Changed
- added `tests/compat_fixtures.rs` to verify `glint` against checked-in compatibility fixtures
- added seed fixtures under `compat/fixtures/` for the common path
- added containerized upstream-capture tooling in `compat/` for generating or refreshing fixtures from `zsh-git-prompt`
- fixed the capture path so generated fixtures preserve significant prefix/suffix whitespace and detached-head cases remain replayable across runs
- updated docs and README language to reflect the fixture-driven compatibility workflow
- added `serde` and `serde_json` test dependencies for fixture parsing

## Stack Context
Base branch: `main`

Current branch: `03-21-add_compat_fixture_harness`

This is now the only open alpha implementation PR. Review it as the remaining fixture-and-contract workflow slice on top of the already-landed foundation and focused CLI coverage.

## Validation
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets`
- `cargo test`

## Risk
Moderate only because this branch adds more tooling and fixture surface area than the branches below it. Normal CI remains on fixture verification, while upstream capture stays an explicit manual workflow.

## Follow-Ups
- Use the generator to capture upstream behavior intentionally, then review fixture diffs before treating them as contract updates.

## Linear
Refs E0D-5
