### PR TITLE
Fix label-gated automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -58,6 +58,7 @@ jobs:
         if: steps.target.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.target.outputs.number }}
         run: |
           set -euo pipefail
@@ -78,7 +79,10 @@ jobs:
           pr_url="$(printf '%s' "${pr_json}" | jq -r '.url')"
 
           ci_green="$(printf '%s' "${checks_json}" | jq -r 'map(select(.workflow == "CI" and .name == "fmt, clippy, test, build" and .bucket == "pass")) | length > 0')"
-          checks_clear="$(printf '%s' "${checks_json}" | jq -r 'length > 0 and all(.[]; .bucket == "pass" or .bucket == "skipping")')"
+          checks_clear="$(printf '%s' "${checks_json}" | jq -r '
+            map(select(.workflow != "Auto Merge"))
+            | length > 0 and all(.[]; .bucket == "pass" or .bucket == "skipping")
+          ')"
 
           if [ "${state}" != "OPEN" ]; then
             echo "PR ${PR_NUMBER} is not open; skipping."
@@ -124,6 +128,7 @@ jobs:
         if: steps.gate.outputs.ready == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.target.outputs.number }}
           HEAD_SHA: ${{ steps.gate.outputs.head_sha }}
         run: |


### PR DESCRIPTION
## Summary
Fix the label-gated automerge workflow so it can run from GitHub Actions without a checked-out repository and so it does not block on its own in-flight check.

## Why
PRs targeting `main` are currently showing a red `Auto Merge` check even when CI is green. The workflow was invoking `gh` as if it were inside a local git checkout, and it also counted its own check run when deciding whether all checks had passed.

## What Changed
- set `GH_REPO` for the workflow steps that invoke `gh`, so the CLI talks to the correct repository without relying on local git metadata
- excluded the `Auto Merge` workflow from the all-checks-green predicate so the gate can evaluate while its own run is still active
- kept the existing branch-target and label gating behavior unchanged

## Stack Context
Base branch: `main`

Current branch: `03-21-fix_label_gated_automerge`

This is the new infra base for the open implementation stack. Merge this first to restore a clean check set on the remaining PRs.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/automerge.yml")'`
- `GH_REPO=e0da/glint gh pr view 1 --json number,baseRefName`
- `GH_REPO=e0da/glint gh pr checks 1 --json bucket,name,workflow`

## Risk
Low. This only changes how the workflow queries GitHub and how it interprets the check set; it does not widen merge permissions or change the label policy.

## Follow-Ups
- Merge this PR first.
- Then the remaining stack will retarget onto `main`, and the `Auto Merge` check should stop failing for repository-context reasons.
