### PR TITLE
Add local hooks and checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "pre-commit: cargo is required to format Rust sources" >&2
+  exit 1
+fi
+
+if ! git diff --cached --name-only --diff-filter=ACMR | grep -Eq '(^|/)(Cargo\.toml|Cargo\.lock|.*\.rs)$'; then
+  exit 0
+fi
+
+echo "pre-commit: running cargo fmt --all"
+cargo fmt --all
+
+git add Cargo.toml Cargo.lock '*.rs' 2>/dev/null || true

--- a/docs/doctrine.md
+++ b/docs/doctrine.md
@@ -5,6 +5,7 @@
 - Use trunk-based development.
 - `main` is trunk.
 - Use Graphite (`gt`) for stacked branches and PRs.
+- Install repo hooks with `./scripts/install-hooks.sh`.
 - Keep each branch focused on one reviewable concern.
 - Prefer `gt c -am "message"` after making changes.
 - Use `gt m -a` for follow-up edits on the current branch.
@@ -14,6 +15,7 @@
 ## Solo Maintainer Policy
 
 - The repo currently relies on workflow discipline rather than branch protection.
+- Keep `./scripts/check.sh` green before submitting or merging a branch.
 - Merge only after the PR is green locally and in GitHub Actions.
 - Use Graphite stacks to keep changes small and auditable even without required approvals.
 - Use the `approved[e0da]` label as the merge gate for label-based automerge.

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+if [ ! -f Cargo.toml ]; then
+  echo "No Cargo.toml yet; skipping Rust checks on the bootstrap branch."
+  exit 0
+fi
+
+cargo fmt --all --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-targets
+cargo build --release

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+git config core.hooksPath "$repo_root/.githooks"
+
+echo "Installed Git hooks from $repo_root/.githooks"


### PR DESCRIPTION
## Summary
Add repo-local Git hooks and a canonical local check script so formatting and CI drift are caught before Graphite submit or merge.

## Why
The recent `rustfmt` mismatch on PR #1 was a pure local workflow miss. This repo already has CI as a backstop, but it did not have a durable local guardrail. A tracked hook plus one canonical check command is the smallest setup that catches this class of mistake without adding another toolchain layer.

## What Changed
- added `.githooks/pre-commit` to run `cargo fmt --all` before commits that touch Rust or Cargo files
- added `scripts/install-hooks.sh` to install the tracked hooks via `core.hooksPath`
- added `scripts/check.sh` as the canonical local verification command
- made `scripts/check.sh` bootstrap-safe so it skips Rust checks until `Cargo.toml` exists on trunk
- documented hook installation and the local check expectation in `docs/doctrine.md`

## Stack Context
Base branch: `main`

Current branch: `03-21-add_local_hooks_and_checks`

This is the new workflow base for the open implementation stack. Merge this first so the remaining branches inherit the repo-local guardrails.

## Validation
- `./scripts/install-hooks.sh`
- `git config --get core.hooksPath`
- `./scripts/check.sh`
- `gt m -a` on PR #1 triggered the pre-commit hook as expected

## Risk
Low. The hook only engages when staged files include Rust or Cargo inputs, and CI remains the final backstop.

## Follow-Ups
- Merge this PR first.
- Then restack the remaining stack onto `main`.
- On any machine that works on the repo, run `./scripts/install-hooks.sh` once after checkout.
