### PR TITLE
Fix automerge branch cleanup

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+## Why
+
+## What Changed
+
+## Linear
+Refs E0D-____
+Use `Fixes E0D-____` only when this PR should close the issue after landing on `main`.
+
+## Stack Context
+Base branch: `...`
+
+Current branch: `...`
+
+## Validation
+- `./scripts/check.sh`
+
+## Risk

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -133,4 +133,4 @@ jobs:
           HEAD_SHA: ${{ steps.gate.outputs.head_sha }}
         run: |
           set -euo pipefail
-          gh pr merge "${PR_NUMBER}" --rebase --delete-branch --match-head-commit "${HEAD_SHA}"
+          gh pr merge "${PR_NUMBER}" --rebase --match-head-commit "${HEAD_SHA}"

--- a/docs/doctrine.md
+++ b/docs/doctrine.md
@@ -5,12 +5,17 @@
 - Use trunk-based development.
 - `main` is trunk.
 - Use Graphite (`gt`) for stacked branches and PRs.
+- Track planned work in Linear under the `glint` project.
 - Install repo hooks with `./scripts/install-hooks.sh`.
+- Start each non-trivial branch from one Linear issue.
+- Prefer a branch name that includes the Linear issue ID.
 - Keep each branch focused on one reviewable concern.
 - Prefer `gt c -am "message"` after making changes.
 - Use `gt m -a` for follow-up edits on the current branch.
 - Use `gt restack` when stack relationships change.
 - Submit reviewable slices early with `gt ss`.
+- Include a Linear reference in every PR body with `Refs E0D-123`.
+- Use `Fixes E0D-123` only on the PR that should close the issue when it lands on `main`.
 
 ## Solo Maintainer Policy
 
@@ -18,6 +23,8 @@
 - Keep `./scripts/check.sh` green before submitting or merging a branch.
 - Merge only after the PR is green locally and in GitHub Actions.
 - Use Graphite stacks to keep changes small and auditable even without required approvals.
+- Let Graphite retarget stacked PRs after a merge; do not rely on GitHub Actions to delete merged stack branches immediately.
+- Keep stacked PRs linked to their own Linear issue instead of sharing one umbrella issue across the stack.
 - Use the `approved[e0da]` label as the merge gate for label-based automerge.
 - Use `do-not-merge` to block automerge without rewriting the branch.
 - Automerge only applies once a PR targets `main`; stacked child PRs wait until restack promotes them to trunk.


### PR DESCRIPTION
## Summary
Fix the label-gated automerge workflow so stacked child PRs are not closed when a downstack PR lands, and add the shared PR template/process guidance that supports the stack workflow.

## Why
The previous workflow merged a PR and immediately deleted its branch. In a Graphite stack, child PRs can still target that branch for a brief window while Graphite retargets them. Deleting the branch inside Actions can therefore close valid child PRs before the stack settles. The repo also benefits from a single lower-stack source of truth for PR metadata and Linear references.

## What Changed
- removed `--delete-branch` from the GitHub Actions merge step
- added a shared pull request template with Linear, stack-context, validation, and risk sections
- documented the stack-safety and Linear-linking rules in the doctrine so branch cleanup stays a local `gt sync` responsibility instead of an Actions responsibility

## Stack Context
Base branch: `main`

Current branch: `03-21-fix_automerge_branch_cleanup`

This must land before the remaining stack so child PRs can promote onto `main` safely.

## Validation
- `./scripts/check.sh`
- latest GitHub Actions `fmt, clippy, test, build` run passed

## Risk
Low. The workflow becomes less aggressive, not more. The only behavior change is that merged stack branches are no longer deleted immediately by Actions.

## Linear
Refs E0D-11