### PR TITLE
Harden automerge stack promotion

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          pr_json="$(gh pr view "${PR_NUMBER}" --json baseRefName,headRefOid,isDraft,labels,state,url)"
+          pr_json="$(gh pr view "${PR_NUMBER}" --json baseRefName,headRefName,headRefOid,isDraft,labels,state,url)"
           checks_json="$(gh pr checks "${PR_NUMBER}" --json bucket,name,workflow 2>/dev/null || true)"
 
           if [ -z "${checks_json}" ]; then
@@ -73,6 +73,7 @@ jobs:
           has_approval_label="$(printf '%s' "${pr_json}" | jq -r '[.labels[].name] | index("approved[e0da]") != null')"
           has_block_label="$(printf '%s' "${pr_json}" | jq -r '[.labels[].name] | index("do-not-merge") != null')"
           base_ref="$(printf '%s' "${pr_json}" | jq -r '.baseRefName')"
+          head_ref_name="$(printf '%s' "${pr_json}" | jq -r '.headRefName')"
           is_draft="$(printf '%s' "${pr_json}" | jq -r '.isDraft')"
           state="$(printf '%s' "${pr_json}" | jq -r '.state')"
           head_sha="$(printf '%s' "${pr_json}" | jq -r '.headRefOid')"
@@ -121,8 +122,42 @@ jobs:
           fi
 
           echo "PR ${PR_NUMBER} is ready for merge: ${pr_url}"
+          echo "base_ref=${base_ref}" >> "${GITHUB_OUTPUT}"
+          echo "head_ref_name=${head_ref_name}" >> "${GITHUB_OUTPUT}"
           echo "head_sha=${head_sha}" >> "${GITHUB_OUTPUT}"
           echo "ready=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Promote direct child PRs
+        if: steps.gate.outputs.ready == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          BASE_REF: ${{ steps.gate.outputs.base_ref }}
+          HEAD_REF_NAME: ${{ steps.gate.outputs.head_ref_name }}
+        run: |
+          set -euo pipefail
+
+          children_json="$(gh pr list --state open --base "${HEAD_REF_NAME}" --json number,url)"
+          child_count="$(printf '%s' "${children_json}" | jq 'length')"
+
+          if [ "${child_count}" -eq 0 ]; then
+            echo "No direct child PRs target ${HEAD_REF_NAME}."
+            exit 0
+          fi
+
+          printf '%s' "${children_json}" | jq -c '.[]' | while read -r child; do
+            child_number="$(printf '%s' "${child}" | jq -r '.number')"
+            child_url="$(printf '%s' "${child}" | jq -r '.url')"
+            echo "Retargeting child PR ${child_number} to ${BASE_REF}: ${child_url}"
+            gh pr edit "${child_number}" --base "${BASE_REF}"
+          done
+
+          remaining_children="$(gh pr list --state open --base "${HEAD_REF_NAME}" --json number | jq 'length')"
+
+          if [ "${remaining_children}" -ne 0 ]; then
+            echo "Refusing to merge while ${remaining_children} child PR(s) still target ${HEAD_REF_NAME}."
+            exit 1
+          fi
 
       - name: Merge PR
         if: steps.gate.outputs.ready == 'true'
@@ -133,4 +168,8 @@ jobs:
           HEAD_SHA: ${{ steps.gate.outputs.head_sha }}
         run: |
           set -euo pipefail
-          gh pr merge "${PR_NUMBER}" --rebase --match-head-commit "${HEAD_SHA}"
+          gh api \
+            --method PUT \
+            "repos/${GH_REPO}/pulls/${PR_NUMBER}/merge" \
+            -f merge_method=rebase \
+            -f sha="${HEAD_SHA}"

--- a/docs/doctrine.md
+++ b/docs/doctrine.md
@@ -24,6 +24,7 @@
 - Merge only after the PR is green locally and in GitHub Actions.
 - Use Graphite stacks to keep changes small and auditable even without required approvals.
 - Let Graphite retarget stacked PRs after a merge; do not rely on GitHub Actions to delete merged stack branches immediately.
+- The label-gated automerge workflow may proactively retarget direct child PRs to the merged PR's base branch before merging so stack promotion stays safe even if the merged branch disappears immediately after. If any direct child PR still targets the soon-to-be-merged branch after that promotion step, the workflow must fail instead of merging.
 - Keep stacked PRs linked to their own Linear issue instead of sharing one umbrella issue across the stack.
 - Use the `approved[e0da]` label as the merge gate for label-based automerge.
 - Use `do-not-merge` to block automerge without rewriting the branch.


### PR DESCRIPTION
## Summary
Harden label-gated automerge so stacked child PRs survive base-branch deletion and promote safely when a downstack PR lands.

## Why
The previous workflow still resulted in `github-actions[bot]` deleting the merged branch immediately after merge, which closed child PRs before they could be retargeted. The merge gate needs to be robust even if the merged branch disappears right away.

## What Changed
- switched the merge step from `gh pr merge` to the GitHub pull-request merge API
- added a promotion step that retargets direct child PRs to the merged PR's base branch before merging
- documented the new stack-promotion behavior in the doctrine

## Stack Context
Base branch: `main`

Current branch: `03-21-harden_automerge_stack_promotion`

This must land before the remaining implementation stack so the repaired automerge path governs later approvals.

## Validation
- `./scripts/check.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/automerge.yml")'`

## Risk
Low. The workflow becomes more explicit and defensive around stack promotion.

## Linear
Refs E0D-12
