### PR TITLE
Document performance architecture and strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `glint` will be documented in this file.
 ## [Unreleased]
 
 - Project foundation and documentation for the first alpha release.
+- Document performance architecture and prompt integration strategy.
 
 ## [0.1.0-alpha.1] - 2026-03-21
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ $(glint)
 That command already runs locally from the crate in this repo. The remaining
 work is narrowing the output toward the compatibility contract.
 
+Direct command substitution is the current portable fallback. A higher
+performance shell integration will likely use hook-driven invalidation so
+`glint` does not need to recompute on every prompt render.
+
 ---
 
 ## Compatibility
@@ -79,6 +83,7 @@ The compatibility contract is defined in [docs/spec/git-super-status.md](docs/sp
 ## Docs
 
 - [docs/doctrine.md](docs/doctrine.md)
+- [docs/architecture.md](docs/architecture.md)
 - [docs/spec/git-super-status.md](docs/spec/git-super-status.md)
 - [CHANGELOG.md](CHANGELOG.md)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,91 @@
+# Glint Architecture
+
+## Purpose
+
+This document explains the current `glint` execution model and the performance
+strategy that should guide post-alpha work.
+
+The product contract remains the prompt output shape and compatibility fixtures.
+Performance work is only valuable if it preserves that observable behavior.
+
+## Current Runtime Path
+
+Today `glint` is a single-shot CLI:
+
+1. read theme overrides from the process environment
+2. invoke `git status --porcelain=v2 --branch`
+3. parse the status output into a narrow Rust status model
+4. render the prompt segment
+
+Detached HEAD uses one extra `git rev-parse --short HEAD` call so the rendered
+hash respects Git's configured abbreviation length.
+
+This keeps the implementation simple and already improves substantially on the
+original upstream Python path, which shells out multiple times per refresh.
+
+## Measured Direction
+
+The direct-invocation benchmarks from 2026-03-21 point to three conclusions:
+
+- one `git status --porcelain=v2 --branch` call is already close to the lower
+  bound for the current CLI shape
+- replacing that with several smaller Git plumbing commands is slower, not
+  faster
+- the remaining large win is avoiding unnecessary recomputation, not splitting
+  the same work across more subprocesses
+
+In other words, "more strategic" should mean "run less often" before it means
+"run different Git commands."
+
+## Performance Layers
+
+Treat prompt performance as two related but distinct layers.
+
+### Direct Invocation
+
+This is the cost of running `glint` once in a repository.
+
+It covers:
+
+- process startup
+- theme/env handling
+- Git state collection
+- parsing and rendering
+
+This layer should stay small, predictable, and easy to benchmark locally.
+
+### Integrated Shell Usage
+
+This is the cost a user actually feels while typing in a shell prompt setup.
+
+It covers:
+
+- when prompt state is refreshed
+- which commands invalidate cached state
+- whether directory changes force recomputation
+- whether non-Git commands reuse the last known prompt state
+
+Upstream `zsh-git-prompt` already wins some real-world latency here through hook
+driven invalidation. A direct `$(glint)` substitution remains a useful fallback,
+but it is not the end-state for a best-in-class prompt component.
+
+## Strategic Direction
+
+The preferred order for performance work is:
+
+1. define a direct invocation budget and measurement method
+2. define a shell-integration invalidation strategy that avoids needless runs
+3. add regression checks for both layers
+4. only then explore a native Git backend if it can beat the porcelain path
+   without compromising compatibility
+
+## Guardrails
+
+Prefer these constraints while improving performance:
+
+- keep the compatibility fixture contract authoritative
+- keep a simple direct CLI path even if richer shell integration lands later
+- do not replace one Git subprocess with many subprocesses in the hot path
+- do not add speculative caching without a clear invalidation model
+- do not claim best-in-class performance from microbenchmarks alone; measure
+  both direct invocation and integrated shell behavior

--- a/docs/doctrine.md
+++ b/docs/doctrine.md
@@ -48,6 +48,10 @@
 - Add fixtures for representative Git states before widening implementation.
 - Use unit tests for pure parsing and rendering logic.
 - Use integration tests for the CLI boundary.
+- Measure prompt latency in two layers: direct invocation cost and integrated
+  shell behavior.
+- Keep latency checks tied to an explicit invalidation strategy, not only raw
+  command runtime.
 
 ## Design Rules
 
@@ -55,3 +59,5 @@
 - Push filesystem, process, and Git I/O to the edges.
 - Keep docs short and honest about current state.
 - Add new docs only when they protect correctness, reviewability, or onboarding.
+- Treat command execution policy and invalidation strategy as product
+  architecture, not shell glue.


### PR DESCRIPTION
## Summary

- add `docs/architecture.md` to capture the current runtime path, measured performance direction, and shell-integration strategy guardrails
- clarify in `README.md` that direct `$(glint)` command substitution is the current portable fallback rather than the long-term high-performance path
- extend `docs/doctrine.md` and `CHANGELOG.md` so the repo doctrine and release notes reflect the new architecture guidance

## Why

The repo needed one durable place to explain the performance model behind `glint` instead of leaving that reasoning scattered across chat and ad hoc notes.

This PR makes two distinctions explicit:

- direct invocation cost and integrated shell behavior are different performance layers
- invalidation strategy is product architecture, not shell glue

## What Changed

- added `docs/architecture.md` with the current CLI runtime path, measured direction, performance layers, strategic direction, and guardrails
- updated `README.md` to point at the architecture doc and describe the current direct-substitution path honestly
- updated `docs/doctrine.md` to require explicit latency-layer thinking and invalidation strategy
- noted the documentation slice in `CHANGELOG.md`

## Linear

Refs E0D-45

## Stack Context

Base branch: `main`

Current branch: `03-21-document_performance_architecture_and_strategy`

Downstack follow-up: #14 `03-21-e0d-67_fix_compat_harness_defaults_and_document_decisions`

## Validation

- `./scripts/check.sh`
- GitHub Actions `fmt, clippy, test, build`

## Risk

- low; docs-only change with no behavior or fixture updates
- the benchmark corpus is not yet captured in the repo, so future performance claims should stay aligned with follow-up benchmark work rather than drift beyond documented evidence

## Follow-Ups

- E0D-45: define the invalidation model and first-class shell integration path
- E0D-66: capture the repeatable benchmark corpus and measurement harness
- E0D-12 / E0D-17: turn performance and prompt-safety decisions into durable regression checks
