### PR TITLE
E0D-67 fix compat harness defaults and document decisions

### DIFF
--- a/compat/README.md
+++ b/compat/README.md
@@ -45,6 +45,46 @@ This keeps the workflow spec-first:
 4. Invoke upstream `git_super_status` under controlled theme variables.
 5. Write JSON fixtures into `compat/fixtures/`.
 
+The wrapper defaults `UPSTREAM_SCRIPT` to `zshrc.sh`, which matches the current
+upstream `master` layout. Override it only when targeting a different upstream
+script path deliberately.
+
+## Generator Language Decision
+
+Keep the upstream-capture generator in Python for now.
+
+Current rationale from the 2026-03-21 investigation:
+
+- the generator is isolated to the expensive refresh path, not the normal
+  Rust runtime path
+- the current implementation is stdlib-only and already fits the container
+  model cleanly
+- measured cost is dominated by external `git` and `zsh` subprocess work,
+  not by Python startup or execution
+- most of the script's size is compatibility-case declaration rather than
+  complex Python-specific logic
+
+Revisit the language only if the harness develops real maintenance pain or a
+clear workflow need. Treat any future rewrite as a maintainability decision,
+not a performance project.
+
+## Base Image Decision
+
+Keep the compatibility harness on `ubuntu:24.04` for now.
+
+Current rationale from the 2026-03-21 investigation:
+
+- Ubuntu and Debian slim produced the same generated fixture corpus in the
+  current harness shape
+- Alpine built smaller and faster, but changed the generated fixture corpus
+- for a compatibility-capture path, stable observable behavior matters more
+  than image size alone
+- Debian slim remains a credible future option, but it does not currently
+  justify churn on its own
+
+Revisit the base image only if a stronger operational need appears or the
+harness changes enough to justify re-running the comparison.
+
 ## Review Rule
 
 Generated fixture changes are not automatically accepted as product truth.

--- a/compat/generate-upstream-fixtures.sh
+++ b/compat/generate-upstream-fixtures.sh
@@ -6,7 +6,7 @@ REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 
 UPSTREAM_REPO=${UPSTREAM_REPO:-https://github.com/olivierverdier/zsh-git-prompt.git}
 UPSTREAM_REF=${UPSTREAM_REF:-master}
-UPSTREAM_SCRIPT=${UPSTREAM_SCRIPT:-gitprompt.sh}
+UPSTREAM_SCRIPT=${UPSTREAM_SCRIPT:-zshrc.sh}
 IMAGE_TAG=${IMAGE_TAG:-glint-compat-harness}
 
 docker build -f "$SCRIPT_DIR/Dockerfile" -t "$IMAGE_TAG" "$REPO_ROOT"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,6 +23,35 @@ hash respects Git's configured abbreviation length.
 This keeps the implementation simple and already improves substantially on the
 original upstream Python path, which shells out multiple times per refresh.
 
+## Compatibility Capture Path
+
+The upstream compatibility-capture harness remains a separate, containerized
+Python workflow in `compat/`.
+
+That is an intentional choice for now.
+
+The 2026-03-21 investigation found that this path is dominated by external
+`git` and `zsh` subprocess orchestration rather than host-language runtime
+cost. The current generator is also stdlib-only and mostly expresses fixture
+cases, not complex Python-specific logic.
+
+In practice, this means:
+
+- keep the expensive upstream-capture path isolated from the Rust runtime path
+- do not treat a Python-to-TypeScript rewrite as a performance lever
+- revisit the language only if maintainability or workflow costs become real
+  enough to justify the rewrite
+- if TypeScript is ever reconsidered for this path, evaluate it as a workflow
+  choice first
+
+The harness also stays on an Ubuntu base image for now.
+
+The 2026-03-21 container-base investigation found that Alpine changed the
+generated fixture corpus, while Ubuntu and Debian slim matched each other.
+That makes image size a secondary concern here: the compatibility harness
+should prefer distro behavior that stays boring and stable over the smallest
+possible container footprint.
+
 ## Measured Direction
 
 The direct-invocation benchmarks from 2026-03-21 point to three conclusions:


### PR DESCRIPTION
## Summary

- fix the compatibility-harness wrapper to default `UPSTREAM_SCRIPT` to the current upstream script path
- document the accepted decisions to keep the upstream-capture generator in Python and the harness container on `ubuntu:24.04`
- make the wrapper executable so the documented direct invocation works as written

## Why

The accepted investigation results were not fully reflected in the repo yet.

Two gaps remained:

- the wrapper still defaulted to `gitprompt.sh` even though the current upstream layout uses `zshrc.sh`
- the repo docs did not record the accepted Python and Ubuntu decisions in the harness docs themselves

## What Changed

- changed `compat/generate-upstream-fixtures.sh` to default `UPSTREAM_SCRIPT` to `zshrc.sh`
- restored the executable bit on `compat/generate-upstream-fixtures.sh`
- updated `compat/README.md` with the wrapper default, the Python generator decision, and the Ubuntu base-image decision
- updated `docs/architecture.md` to record the Python and Ubuntu decisions in the broader runtime architecture story

## Linear

Refs E0D-67

Also documents the resolved generator-language decision from E0D-56.

## Stack Context

Base branch: `03-21-document_performance_architecture_and_strategy` (#13)

Current branch: `03-21-e0d-67_fix_compat_harness_defaults_and_document_decisions`

This PR should merge after #13 because it narrows and documents a follow-up decision on top of the new architecture doc.

## Validation

- `./scripts/check.sh`
- verified `./compat/generate-upstream-fixtures.sh` against a temporary copy of the repo with no `UPSTREAM_SCRIPT` override
- confirmed the wrapper generated `compat/fixtures/zsh-git-prompt-common-path.generated.json`
- GitHub Actions `fmt, clippy, test, build`

## Risk

- low; narrow wrapper and docs change with no Rust behavior changes
- if upstream changes the script path again, the wrapper can still be overridden with `UPSTREAM_SCRIPT`, but the default may need to move again later

## Follow-Ups

- no immediate code follow-up is required from this slice
- future language or base-image revisits should go through new evidence-led Linear investigations rather than ad hoc changes
