### PR TITLE
E0D-12 define prompt latency budget and regression check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target/
+/tmp/benchmark-corpus/
+/tmp/benchmark-results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `glint` will be documented in this file.
 
 - Project foundation and documentation for the first alpha release.
 - Document performance architecture and prompt integration strategy.
+- Add a repeatable benchmark corpus and latency harness for direct and shell fallback measurements.
 
 ## [0.1.0-alpha.1] - 2026-03-21
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The compatibility contract is defined in [docs/spec/git-super-status.md](docs/sp
 - [docs/doctrine.md](docs/doctrine.md)
 - [docs/architecture.md](docs/architecture.md)
 - [docs/spec/git-super-status.md](docs/spec/git-super-status.md)
+- [docs/spec/prompt-latency.md](docs/spec/prompt-latency.md)
 - [CHANGELOG.md](CHANGELOG.md)
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,6 +66,31 @@ The direct-invocation benchmarks from 2026-03-21 point to three conclusions:
 In other words, "more strategic" should mean "run less often" before it means
 "run different Git commands."
 
+## Repeatable Benchmark Harness
+
+The repo now carries a small latency harness so performance decisions can be
+rechecked against the same corpus instead of relying on one-off numbers.
+
+Use `./scripts/benchmark.sh` to regenerate the benchmark corpus in
+`tmp/benchmark-corpus/` and record fresh results in `tmp/benchmark-results/`.
+
+The corpus intentionally stays small:
+
+- `outside-git`: empty directory for the no-output path
+- `clean`: tracked branch with no local changes
+- `detached-clean`: detached HEAD on a clean commit
+- `dirty`: staged, changed, and untracked local work
+- `tracking-diverged`: local and remote history diverged after a fetch
+
+The harness reports two layers separately:
+
+- `direct`: invoke the built `glint` binary directly inside each corpus repo
+- `shell`: invoke `glint` through a fresh `zsh -f` command-substitution path
+
+That shell measurement is intentionally the current portable fallback, not the
+future hook-driven invalidation model. It exists so alpha-era numbers remain
+comparable until the first-class shell integration contract is settled.
+
 ## Performance Layers
 
 Treat prompt performance as two related but distinct layers.

--- a/docs/spec/prompt-latency.md
+++ b/docs/spec/prompt-latency.md
@@ -1,0 +1,62 @@
+# Prompt Latency Contract
+
+## Purpose
+
+This document defines the alpha latency budget for `glint` on the benchmark
+corpus carried in this repo.
+
+The benchmark harness exists to keep the performance discussion grounded in
+repeatable measurements instead of one-off shell timings.
+
+## Measurement Commands
+
+Use these commands from the repo root:
+
+```sh
+./scripts/benchmark.sh direct
+./scripts/benchmark.sh shell
+./scripts/check-latency.sh
+```
+
+`./scripts/benchmark.sh` regenerates the corpus in `tmp/benchmark-corpus/` and
+writes raw samples plus a tab-separated summary to `tmp/benchmark-results/`.
+
+## Benchmark Corpus
+
+The alpha corpus consists of these repository shapes:
+
+- `outside-git`
+- `clean`
+- `detached-clean`
+- `dirty`
+- `tracking-diverged`
+
+These cases are intentionally small. They cover the direct CLI happy path, the
+detached-HEAD extra-Git-call path, and the current no-output fallback outside a
+repo.
+
+## Alpha Budget
+
+The alpha budget applies to every corpus repo in the harness summary:
+
+- `direct` median: at most `15 ms`
+- `direct` p95: at most `40 ms`
+- `shell` median: at most `20 ms`
+- `shell` p95: at most `45 ms`
+
+## Shell Assumption
+
+The `shell` mode measures the current portable fallback: a fresh `zsh -f`
+invocation that renders prompt output through `$(glint)`.
+
+This is not the future hook-driven invalidation path. It is only the
+comparable alpha baseline until the first-class shell integration contract is
+defined.
+
+## Guardrails
+
+- Do not compare new numbers against a different corpus and call it equivalent.
+- Do not treat multiple smaller Git subprocesses as an acceptable substitute for
+  the single porcelain baseline unless the benchmark corpus shows a real win.
+- Keep regression checks tied to this harness so the measured budget and the
+  enforcement path stay aligned.

--- a/scripts/bench/prepare-corpus.sh
+++ b/scripts/bench/prepare-corpus.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+OUT_DIR=${1:-"$ROOT_DIR/tmp/benchmark-corpus"}
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+git_init_repo() {
+  repo=$1
+  git init -b main "$repo" >/dev/null
+  git -C "$repo" config user.name glint-bench >/dev/null
+  git -C "$repo" config user.email glint-bench@example.com >/dev/null
+}
+
+write_file() {
+  path=$1
+  contents=$2
+  mkdir -p "$(dirname "$path")"
+  printf '%s\n' "$contents" > "$path"
+}
+
+commit_file() {
+  repo=$1
+  path=$2
+  contents=$3
+  message=$4
+  write_file "$repo/$path" "$contents"
+  git -C "$repo" add "$path"
+  git -C "$repo" commit -m "$message" >/dev/null
+}
+
+outside_git_repo() {
+  mkdir -p "$OUT_DIR/outside-git"
+}
+
+clean_repo() {
+  repo="$OUT_DIR/clean"
+  git_init_repo "$repo"
+  commit_file "$repo" tracked.txt "clean" "Initial commit"
+}
+
+detached_clean_repo() {
+  repo="$OUT_DIR/detached-clean"
+  git_init_repo "$repo"
+  commit_file "$repo" tracked.txt "detached" "Initial commit"
+  git -C "$repo" checkout --detach >/dev/null 2>&1
+}
+
+dirty_repo() {
+  repo="$OUT_DIR/dirty"
+  git_init_repo "$repo"
+  commit_file "$repo" tracked.txt "clean" "Initial commit"
+  commit_file "$repo" changed.txt "base" "Add changed file"
+  write_file "$repo/staged.txt" "staged"
+  git -C "$repo" add staged.txt
+  write_file "$repo/changed.txt" "dirty"
+  write_file "$repo/untracked.txt" "untracked"
+}
+
+tracking_diverged_repo() {
+  remote="$OUT_DIR/tracking-diverged-remote.git"
+  repo="$OUT_DIR/tracking-diverged"
+  peer="$OUT_DIR/tracking-diverged-peer"
+
+  git init --bare "$remote" >/dev/null
+  git_init_repo "$repo"
+  commit_file "$repo" tracked.txt "base" "Initial commit"
+  git -C "$repo" remote add origin "$remote"
+  git -C "$repo" push -u origin main >/dev/null
+
+  git clone --branch main "$remote" "$peer" >/dev/null
+  git -C "$peer" config user.name glint-bench >/dev/null
+  git -C "$peer" config user.email glint-bench@example.com >/dev/null
+  commit_file "$peer" peer.txt "peer" "Peer commit"
+  git -C "$peer" push origin main >/dev/null
+
+  commit_file "$repo" local.txt "local" "Local commit"
+  git -C "$repo" fetch origin >/dev/null
+
+  rm -rf "$peer"
+}
+
+outside_git_repo
+clean_repo
+detached_clean_repo
+dirty_repo
+tracking_diverged_repo
+
+printf '%s\n' \
+  "$OUT_DIR/outside-git" \
+  "$OUT_DIR/clean" \
+  "$OUT_DIR/detached-clean" \
+  "$OUT_DIR/dirty" \
+  "$OUT_DIR/tracking-diverged"

--- a/scripts/bench/render-prompt.zsh
+++ b/scripts/bench/render-prompt.zsh
@@ -1,0 +1,18 @@
+#!/usr/bin/env zsh
+set -eu
+
+binary=${1:?expected glint binary path}
+
+export ZSH_THEME_GIT_PROMPT_PREFIX="("
+export ZSH_THEME_GIT_PROMPT_SUFFIX=")"
+export ZSH_THEME_GIT_PROMPT_SEPARATOR="|"
+export ZSH_THEME_GIT_PROMPT_BRANCH=""
+export ZSH_THEME_GIT_PROMPT_STAGED="●"
+export ZSH_THEME_GIT_PROMPT_CONFLICTS="✖"
+export ZSH_THEME_GIT_PROMPT_CHANGED="✚"
+export ZSH_THEME_GIT_PROMPT_BEHIND="↓"
+export ZSH_THEME_GIT_PROMPT_AHEAD="↑"
+export ZSH_THEME_GIT_PROMPT_UNTRACKED="…"
+export ZSH_THEME_GIT_PROMPT_CLEAN="✔"
+
+print -P -- "$("$binary")" >/dev/null

--- a/scripts/bench/run-timed.zsh
+++ b/scripts/bench/run-timed.zsh
@@ -1,0 +1,23 @@
+#!/usr/bin/env zsh
+set -eu
+
+zmodload zsh/datetime
+
+runs=${1:?expected run count}
+warmup=${2:?expected warmup count}
+cwd=${3:?expected cwd}
+shift 3
+
+cd "$cwd"
+
+integer i
+for ((i = 0; i < warmup; i += 1)); do
+  "$@" >/dev/null
+done
+
+for ((i = 0; i < runs; i += 1)); do
+  start=$EPOCHREALTIME
+  "$@" >/dev/null
+  end=$EPOCHREALTIME
+  printf '%.6f\n' "$(((end - start) * 1000.0))"
+done

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,0 +1,134 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+CORPUS_DIR=${GLINT_BENCH_CORPUS_DIR:-"$ROOT_DIR/tmp/benchmark-corpus"}
+RESULTS_DIR=${GLINT_BENCH_RESULTS_DIR:-"$ROOT_DIR/tmp/benchmark-results"}
+RUNS=${GLINT_BENCH_RUNS:-30}
+WARMUP=${GLINT_BENCH_WARMUP:-5}
+MODE=${1:-all}
+
+case "$MODE" in
+  direct|shell|all)
+    ;;
+  *)
+    echo "usage: $0 [direct|shell|all]" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$RESULTS_DIR"
+rm -f "$RESULTS_DIR"/*.samples.txt "$RESULTS_DIR"/summary.tsv
+
+"$ROOT_DIR/scripts/bench/prepare-corpus.sh" "$CORPUS_DIR" >/dev/null
+cargo build --release >/dev/null
+
+BINARY="$ROOT_DIR/target/release/glint"
+RUNNER="$ROOT_DIR/scripts/bench/run-timed.zsh"
+SHELL_RENDER="$ROOT_DIR/scripts/bench/render-prompt.zsh"
+SUMMARY="$RESULTS_DIR/summary.tsv"
+
+printf 'mode\trepo\truns\tmedian_ms\tp95_ms\tmean_ms\tmin_ms\tmax_ms\n' > "$SUMMARY"
+
+summarize_case() {
+  mode=$1
+  repo_name=$2
+  cwd=$3
+  shift 3
+
+  sample_file="$RESULTS_DIR/$mode-$repo_name.samples.txt"
+  "$RUNNER" "$RUNS" "$WARMUP" "$cwd" "$@" > "$sample_file"
+
+  sort -n "$sample_file" | awk -v mode="$mode" -v repo="$repo_name" -v runs="$RUNS" '
+    {
+      values[NR] = $1
+      sum += $1
+    }
+    END {
+      if (NR == 0) {
+        exit 1
+      }
+
+      min = values[1]
+      max = values[NR]
+      mean = sum / NR
+      p95_index = int((NR * 95 + 99) / 100)
+      if (p95_index < 1) {
+        p95_index = 1
+      }
+      if (p95_index > NR) {
+        p95_index = NR
+      }
+
+      if (NR % 2 == 1) {
+        median = values[(NR + 1) / 2]
+      } else {
+        median = (values[NR / 2] + values[(NR / 2) + 1]) / 2
+      }
+
+      printf "%s\t%s\t%d\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\n",
+        mode,
+        repo,
+        runs,
+        median,
+        values[p95_index],
+        mean,
+        min,
+        max
+    }
+  ' >> "$SUMMARY"
+}
+
+run_direct() {
+  repo_name=$1
+  cwd=$2
+  summarize_case direct "$repo_name" "$cwd" "$BINARY"
+}
+
+run_shell() {
+  repo_name=$1
+  cwd=$2
+  summarize_case shell "$repo_name" "$cwd" zsh -f "$SHELL_RENDER" "$BINARY"
+}
+
+for repo_name in outside-git clean detached-clean dirty tracking-diverged; do
+  repo_path="$CORPUS_DIR/$repo_name"
+
+  if [ "$MODE" = "direct" ] || [ "$MODE" = "all" ]; then
+    run_direct "$repo_name" "$repo_path"
+  fi
+
+  if [ "$MODE" = "shell" ] || [ "$MODE" = "all" ]; then
+    run_shell "$repo_name" "$repo_path"
+  fi
+done
+
+awk '
+  BEGIN {
+    printf "%-8s %-18s %6s %10s %10s %10s %10s %10s\n",
+      "mode",
+      "repo",
+      "runs",
+      "median_ms",
+      "p95_ms",
+      "mean_ms",
+      "min_ms",
+      "max_ms"
+  }
+  NR == 1 {
+    next
+  }
+  {
+    printf "%-8s %-18s %6s %10s %10s %10s %10s %10s\n",
+      $1,
+      $2,
+      $3,
+      $4,
+      $5,
+      $6,
+      $7,
+      $8
+  }
+' "$SUMMARY"
+
+printf '\nSaved raw samples and summary under %s\n' "$RESULTS_DIR"

--- a/scripts/check-latency.sh
+++ b/scripts/check-latency.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+SUMMARY="$ROOT_DIR/tmp/benchmark-results/summary.tsv"
+
+DIRECT_MEDIAN_BUDGET_MS=${GLINT_DIRECT_MEDIAN_BUDGET_MS:-15}
+DIRECT_P95_BUDGET_MS=${GLINT_DIRECT_P95_BUDGET_MS:-40}
+SHELL_MEDIAN_BUDGET_MS=${GLINT_SHELL_MEDIAN_BUDGET_MS:-20}
+SHELL_P95_BUDGET_MS=${GLINT_SHELL_P95_BUDGET_MS:-45}
+
+"$ROOT_DIR/scripts/benchmark.sh" all
+
+awk -F '\t' \
+  -v direct_median_budget="$DIRECT_MEDIAN_BUDGET_MS" \
+  -v direct_p95_budget="$DIRECT_P95_BUDGET_MS" \
+  -v shell_median_budget="$SHELL_MEDIAN_BUDGET_MS" \
+  -v shell_p95_budget="$SHELL_P95_BUDGET_MS" '
+  NR == 1 {
+    next
+  }
+  {
+    mode = $1
+    repo = $2
+    median = $4 + 0
+    p95 = $5 + 0
+
+    median_budget = mode == "direct" ? direct_median_budget : shell_median_budget
+    p95_budget = mode == "direct" ? direct_p95_budget : shell_p95_budget
+
+    if (median > median_budget) {
+      printf "%s %s median %.3f ms exceeds budget %.3f ms\n", mode, repo, median, median_budget > "/dev/stderr"
+      failed = 1
+    }
+
+    if (p95 > p95_budget) {
+      printf "%s %s p95 %.3f ms exceeds budget %.3f ms\n", mode, repo, p95, p95_budget > "/dev/stderr"
+      failed = 1
+    }
+  }
+  END {
+    exit failed
+  }
+' "$SUMMARY"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -10,3 +10,4 @@ cargo fmt --all --check
 cargo clippy --all-targets --all-features -- -D warnings
 cargo test --all-targets
 cargo build --release
+./scripts/check-latency.sh


### PR DESCRIPTION
## Summary
Define the alpha prompt latency contract and enforce it with a repeatable benchmark harness.

## Why
Performance was documented architecturally, but the alpha project still lacked a concrete budget, a stable benchmark corpus, and an executable regression check.

## What Changed
- added a small benchmark corpus generator for representative repo states
- added direct and shell fallback benchmark scripts plus persisted raw samples
- defined the alpha prompt latency contract and linked it from the README
- wired a latency budget check into `./scripts/check.sh`

## Linear
Refs E0D-12
Refs E0D-66

## Stack Context
Base branch: `main`

Current branch: `03-21-e0d-12_define_prompt_latency_budget_and_regression_check`

## Validation
- `./scripts/check.sh`

## Risk
- latency budgets are calibrated from the current local benchmark harness and intentionally keep the p95 bar loose enough to avoid flaky failures on a busy machine
