### PR TITLE
E0D-13 define prompt-safe failure behavior

### DIFF
--- a/docs/spec/git-super-status.md
+++ b/docs/spec/git-super-status.md
@@ -25,6 +25,16 @@ verifier.
 - Show the clean indicator only when the repository is otherwise clean.
 - Produce no output outside a Git repository.
 
+## Prompt-Safe Failure Behavior
+
+For `0.1.0-alpha.1`, `glint` should fail closed.
+
+- If `glint` cannot derive a complete status segment, it should emit no output.
+- Treat Git subprocess launch failures and non-zero Git exits as no-output cases.
+- Treat malformed or incomplete porcelain output as a no-output case.
+- Keep these prompt-time failures silent rather than printing partial segments or
+  user-facing errors.
+
 ## Prompt Symbols
 
 - Branch marker: `ZSH_THEME_GIT_PROMPT_BRANCH`

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::Command;
 
@@ -11,6 +12,55 @@ fn outside_git_repo_emits_nothing() {
     let repo = repo();
 
     assert_output(repo.path(), "");
+}
+
+#[test]
+fn git_command_failure_emits_nothing() {
+    let repo = repo();
+    let fake_git = fake_git(
+        "\
+#!/bin/sh
+exit 1
+",
+    );
+
+    let output = glint(repo.path())
+        .env("PATH", fake_git.path())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = normalize_output(String::from_utf8(output).unwrap());
+
+    assert_eq!(stdout, "");
+}
+
+#[test]
+fn incomplete_status_output_emits_nothing() {
+    let repo = repo();
+    let fake_git = fake_git(
+        "\
+#!/bin/sh
+if [ \"$1\" = \"status\" ]; then
+  printf '%s\n' '# branch.oid deadbeef'
+  exit 0
+fi
+
+exit 1
+",
+    );
+
+    let output = glint(repo.path())
+        .env("PATH", fake_git.path())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = normalize_output(String::from_utf8(output).unwrap());
+
+    assert_eq!(stdout, "");
 }
 
 #[test]
@@ -239,6 +289,18 @@ fn write_file(repo: &Path, path: &str, contents: &str) {
         fs::create_dir_all(parent).unwrap();
     }
     fs::write(full_path, contents).unwrap();
+}
+
+fn fake_git(script: &str) -> TempDir {
+    let dir = repo();
+    let path = dir.path().join("git");
+    fs::write(&path, script).unwrap();
+
+    let mut permissions = fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).unwrap();
+
+    dir
 }
 
 fn git(repo: &Path, args: impl IntoIterator<Item = impl AsRef<str>>) {


### PR DESCRIPTION
## Summary

- define the alpha prompt-safe failure contract as a silent no-output rule
- add CLI coverage for Git command failures and incomplete porcelain output

## Why

The alpha already treats prompt output as the product contract, but failure-path behavior was only implicit in the implementation. This makes the no-output fallback explicit and executable before broader alpha work continues.

## What Changed

- added a `Prompt-Safe Failure Behavior` section to `docs/spec/git-super-status.md`
- added integration tests that verify `glint` emits nothing when Git exits non-zero or returns incomplete status data
- kept the implementation unchanged because the current behavior already matches the contract

## Linear

Fixes E0D-13

## Stack Context

Base branch: `main`

Current branch: `03-22-e0d-13_define_prompt-safe_error_behavior_outside_the_happy_path`

## Validation

- `cargo test -q --test cli`
- `./scripts/check.sh`

## Risk

- low: this change narrows the documented alpha behavior and adds coverage without changing the runtime path