### PR TITLE
E0D-45 define shell invalidation contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `glint` will be documented in this file.
 - Project foundation and documentation for the first alpha release.
 - Document performance architecture and prompt integration strategy.
 - Add a repeatable benchmark corpus and latency harness for direct and shell fallback measurements.
+- Define the planned hook-driven shell integration and invalidation contract.
 
 ## [0.1.0-alpha.1] - 2026-03-21
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ That command already runs locally from the crate in this repo. The remaining
 work is narrowing the output toward the compatibility contract.
 
 Direct command substitution is the current portable fallback. A higher
-performance shell integration will likely use hook-driven invalidation so
-`glint` does not need to recompute on every prompt render.
+performance shell integration is defined in
+[docs/spec/shell-integration.md](docs/spec/shell-integration.md), but that
+hook-driven path is not shipped yet.
 
 ---
 
@@ -86,6 +87,7 @@ The compatibility contract is defined in [docs/spec/git-super-status.md](docs/sp
 - [docs/architecture.md](docs/architecture.md)
 - [docs/spec/git-super-status.md](docs/spec/git-super-status.md)
 - [docs/spec/prompt-latency.md](docs/spec/prompt-latency.md)
+- [docs/spec/shell-integration.md](docs/spec/shell-integration.md)
 - [CHANGELOG.md](CHANGELOG.md)
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,16 +119,24 @@ It covers:
 - whether directory changes force recomputation
 - whether non-Git commands reuse the last known prompt state
 
-Upstream `zsh-git-prompt` already wins some real-world latency here through hook
-driven invalidation. A direct `$(glint)` substitution remains a useful fallback,
-but it is not the end-state for a best-in-class prompt component.
+The intended first-class contract is now defined in
+`docs/spec/shell-integration.md`.
+
+That contract makes three conservative alpha choices explicit:
+
+- the first-class shell surface is `zsh`
+- prompt state is invalidated after any real command or directory change
+- prompt redraws without an intervening command reuse the cached segment
+
+Direct `$(glint)` substitution remains a useful portable fallback, but it is
+not the end-state for a best-in-class prompt component.
 
 ## Strategic Direction
 
 The preferred order for performance work is:
 
 1. define a direct invocation budget and measurement method
-2. define a shell-integration invalidation strategy that avoids needless runs
+2. implement the settled shell-integration invalidation contract
 3. add regression checks for both layers
 4. only then explore a native Git backend if it can beat the porcelain path
    without compromising compatibility
@@ -141,5 +149,7 @@ Prefer these constraints while improving performance:
 - keep a simple direct CLI path even if richer shell integration lands later
 - do not replace one Git subprocess with many subprocesses in the hot path
 - do not add speculative caching without a clear invalidation model
+- do not guess that a command was read-only unless that rule becomes an explicit
+  part of the contract
 - do not claim best-in-class performance from microbenchmarks alone; measure
   both direct invocation and integrated shell behavior

--- a/docs/spec/prompt-latency.md
+++ b/docs/spec/prompt-latency.md
@@ -49,9 +49,9 @@ The alpha budget applies to every corpus repo in the harness summary:
 The `shell` mode measures the current portable fallback: a fresh `zsh -f`
 invocation that renders prompt output through `$(glint)`.
 
-This is not the future hook-driven invalidation path. It is only the
-comparable alpha baseline until the first-class shell integration contract is
-defined.
+This is not the hook-driven path described in `docs/spec/shell-integration.md`.
+It is only the comparable alpha baseline until that first-class integration is
+implemented.
 
 ## Guardrails
 

--- a/docs/spec/shell-integration.md
+++ b/docs/spec/shell-integration.md
@@ -1,0 +1,85 @@
+# Shell Integration Contract
+
+## Purpose
+
+This document defines the first-class shell integration target for `glint`
+after the direct `$(glint)` fallback.
+
+It is a contract for the intended high-performance path, not a claim that the
+hook-driven path is already implemented.
+
+## Alpha Scope
+
+The first-class shell integration target for `0.1.0-alpha.1` is:
+
+- `zsh` only
+- hook-driven invalidation with no background daemon
+- the same visible prompt output contract as direct `glint` execution
+
+Other shells, or `zsh` setups where the required hooks are unavailable, should
+fall back to direct `$(glint)` execution.
+
+## Hook Surface
+
+The supported hook surface is:
+
+- `precmd` to render or reuse the prompt segment before the prompt is shown
+- `preexec` to mark cached prompt state dirty before a real command runs
+- `chpwd` to invalidate cached prompt state when the working directory changes
+
+This keeps the integration explicit and shell-native instead of inventing a
+hidden service layer.
+
+## Invalidation Model
+
+The first-class path should cache only the last rendered segment for the
+current shell session.
+
+Recompute the prompt segment when any of these are true:
+
+- no cached segment exists yet
+- the previous command triggered `preexec`
+- the shell triggered `chpwd`
+- the current working directory differs from the directory used for the cached
+  segment
+
+Reuse the cached segment when the prompt redraws without an intervening command
+or directory change.
+
+## Command Classes
+
+For the alpha contract, treat commands conservatively:
+
+- any real command execution invalidates the cached prompt state
+- prompt redraws with no intervening command reuse the cached prompt state
+- directory changes always invalidate the cached prompt state
+
+The alpha contract does not attempt a read-only command allowlist. If a command
+ran, `glint` should recompute before the next prompt rather than guessing
+whether the repo stayed unchanged.
+
+## Fallback Behavior
+
+The portable fallback remains direct command substitution:
+
+```zsh
+$(glint)
+```
+
+Fallback mode should:
+
+- remain the only supported path outside the first-class `zsh` hook surface
+- preserve the same visible output contract as the hook-driven path
+- avoid hidden caches, daemons, or partial emulation of hook behavior
+
+## Benchmark And Test Assumptions
+
+Until the hook-driven path exists, the benchmark harness should keep measuring
+the direct substitution fallback for the `shell` layer.
+
+When the hook-driven path is implemented, test and benchmark it against at
+least these cases:
+
+- repeated prompt redraw with no intervening command reuses cached output
+- a completed command invalidates prompt state before the next prompt
+- a directory change invalidates prompt state before the next prompt


### PR DESCRIPTION
## Summary

- define the first-class shell integration target as a conservative zsh hook contract
- add a focused spec for invalidation, fallback behavior, and later benchmark/test assumptions
- align the architecture, latency, README, and changelog docs to that contract

## Why

PR #13 documented the performance direction, but `E0D-45` still lacked the actual invalidation contract. This branch makes the hook model explicit enough for later implementation and testing without pretending the hook path already ships.

## What Changed

- added `docs/spec/shell-integration.md` as the canonical contract for the planned hook-driven path
- defined the alpha shell scope as `zsh` with `precmd`, `preexec`, and `chpwd` hooks
- defined the conservative invalidation rule: recompute after any real command or directory change, reuse only on prompt redraws with no intervening command
- kept `$(glint)` as the explicit portable fallback when hooks are unavailable
- updated `docs/architecture.md`, `docs/spec/prompt-latency.md`, `README.md`, and `CHANGELOG.md` to reflect the settled contract

## Linear

Fixes E0D-45

## Stack Context

Base branch: `main`

Current branch: `03-22-e0d-45_define_prompt_invalidation_and_shell_integration_strategy`

## Validation

- `./scripts/check-latency.sh`
- `./scripts/check.sh`

## Risk

- low: docs-only change with no runtime behavior change
- local latency checking showed one transient detached-clean budget failure before passing on rerun, so the benchmark remains somewhat noise-sensitive even though the final validation was green