### PR TITLE
E0D-7 fail closed on detached-head hash lookup errors

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -35,10 +35,7 @@ pub fn collect_status() -> Option<GitStatus> {
 
     let parsed = parse_status(&String::from_utf8_lossy(&output.stdout))?;
     let branch = if parsed.branch_name == "(detached)" {
-        format!(
-            ":{}",
-            detached_head_oid().or(parsed.branch_oid.clone())?.trim()
-        )
+        format!(":{}", detached_head_oid()?.trim())
     } else {
         parsed.branch_name
     };

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -64,6 +64,38 @@ exit 1
 }
 
 #[test]
+fn detached_head_without_short_hash_emits_nothing() {
+    let repo = repo();
+    let fake_git = fake_git(
+        "\
+#!/bin/sh
+if [ \"$1\" = \"status\" ]; then
+  printf '%s\n' '# branch.oid 70c2952abcdef012345678901234567890123456'
+  printf '%s\n' '# branch.head (detached)'
+  exit 0
+fi
+
+if [ \"$1\" = \"rev-parse\" ]; then
+  exit 1
+fi
+
+exit 1
+",
+    );
+
+    let output = glint(repo.path())
+        .env("PATH", fake_git.path())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = normalize_output(String::from_utf8(output).unwrap());
+
+    assert_eq!(stdout, "");
+}
+
+#[test]
 fn clean_branch_renders_expected_output() {
     let repo = repo();
     init_repo(repo.path());


### PR DESCRIPTION
## Summary

- fix a detached-head edge where a failed short-hash lookup could emit the full porcelain object ID
- add CLI coverage for detached status when `git rev-parse --short HEAD` fails
- keep the prompt-safe contract by emitting nothing instead of the wrong hash shape

## Why

A late science-lab bench found one real remaining alpha rendering gap. When detached status parsing succeeded but the short-hash lookup failed, `glint` could print the full `branch.oid` value instead of the abbrev-respecting detached hash shape.

## What Changed

- removed the fallback from detached rendering to the raw porcelain `branch.oid` value
- added `detached_head_without_short_hash_emits_nothing` to the CLI suite
- kept the normal detached abbrev path intact and verified it still passes

## Linear

Fixes E0D-7

## Stack Context

Base branch: `03-22-e0d-45_define_prompt_invalidation_and_shell_integration_strategy`

Current branch: `03-22-e0d-7_fix_detached_head_fallback_abbrev`

Upstack follow-up: E0D-9 docs honesty pass once this behavior fix is in place

## Validation

- `cargo test -q --test cli detached_head_without_short_hash_emits_nothing`
- `cargo test -q --test cli detached_head_respects_git_abbrev_length`
- `./scripts/check.sh`

## Risk

- low: narrow detached-head edge fix plus coverage
- behavior changes only on the failure path where the previous output shape was already wrong