### PR TITLE
E0D-9 tighten alpha docs honesty pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,11 @@ All notable changes to `glint` will be documented in this file.
 
 ## [Unreleased]
 
+- Current trunk version is `0.1.0-alpha.1`, but no release tag or GitHub
+  Release has been published yet.
+- Until the first alpha tag exists, this changelog is also the temporary
+  release-notes surface.
 - Project foundation and documentation for the first alpha release.
 - Document performance architecture and prompt integration strategy.
 - Add a repeatable benchmark corpus and latency harness for direct and shell fallback measurements.
 - Define the planned hook-driven shell integration and invalidation contract.
-
-## [0.1.0-alpha.1] - 2026-03-21
-
-- Initial alpha target.
-- Common-path `git_super_status` compatibility contract defined.
-- CI and release automation planned from the start.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Fast, minimal Git-aware prompt status as a single binary.
 `glint` is the Rust replacement for `zsh-git-prompt`'s
 `git_super_status` prompt segment.
 
-Current state: the crate and CLI are in place, source installs work, and the
-compatibility surface is still being built out for the first alpha.
+Current state: the crate and CLI are in place, direct source installs work, and
+the first alpha contract is still being finished. Tagged release artifacts and
+hook-driven shell integration are not shipped yet.
 
 ---
 
@@ -20,7 +21,7 @@ binary:
 
 - no prompt scripting dependency
 - one executable
-- releaseable through GitHub Releases
+- planned GitHub Release artifacts once the first alpha tag exists
 
 The first shipped version target is `0.1.0-alpha.1`.
 
@@ -29,9 +30,8 @@ The first shipped version target is `0.1.0-alpha.1`.
 ## Scope
 
 - Git prompt status for the common path
-- Compatibility with `zsh-git-prompt`'s `git_super_status`
-- Trunk-based development with Graphite stacks
-- Executable specs and golden tests for user-visible output
+- Common-path alpha compatibility with `zsh-git-prompt`'s `git_super_status`
+- Executable compatibility fixtures and integration tests for user-visible output
 
 ---
 
@@ -50,23 +50,16 @@ Releases once the first alpha is tagged.
 
 ## Usage
 
-The intended shell integration is:
-
-```zsh
-$(git_super_status)
-```
-
-with:
+Current portable usage is direct command substitution:
 
 ```zsh
 $(glint)
 ```
 
-That command already runs locally from the crate in this repo. The remaining
-work is narrowing the output toward the compatibility contract.
+That path works today from a source install. It is the current fallback path,
+not the long-term high-performance integration.
 
-Direct command substitution is the current portable fallback. A higher
-performance shell integration is defined in
+The planned higher-performance shell integration is defined in
 [docs/spec/shell-integration.md](docs/spec/shell-integration.md), but that
 hook-driven path is not shipped yet.
 
@@ -78,6 +71,8 @@ The first alpha is targeting common-path compatibility with
 `zsh-git-prompt`'s `git_super_status`.
 
 The compatibility contract is defined in [docs/spec/git-super-status.md](docs/spec/git-super-status.md).
+Current automated coverage is centered on that common-path contract rather than
+broader upstream parity.
 
 ---
 


### PR DESCRIPTION
## Summary

- tighten README and changelog wording so they match the actual alpha state on trunk
- remove release-facing claims that imply the first alpha already shipped
- keep the documented compatibility claim aligned to the tested common-path surface

## Why

With the behavior and contract branches stacked underneath, the next honest slice is to make the release-facing docs describe the current alpha reality exactly: source install works, common-path alpha coverage exists, but no tag, GitHub Release, or hook-driven integration has shipped yet.

## What Changed

- narrowed the README scope from generic compatibility language to common-path alpha compatibility
- replaced the README test-language overclaim with the actual proof surface: compatibility fixtures and integration tests
- made the README usage section explicit that direct `$(glint)` is the current portable path and the hook-driven integration is still planned
- removed the premature dated `0.1.0-alpha.1` changelog section and kept those notes under `Unreleased` until a real tag exists
- made `CHANGELOG.md` the explicit temporary release-notes surface until the first alpha tag is cut

## Linear

Fixes E0D-9

## Stack Context

Base branch: `03-22-e0d-7_fix_detached_head_fallback_abbrev`

Current branch: `03-22-e0d-9_tighten_alpha_docs_honesty_pass`

## Validation

- `./scripts/check.sh`

## Risk

- low: docs-only honesty pass with no runtime changes
- wording is intentionally narrower, so the main risk is omission rather than overclaim