### PR TITLE
ci: remove draft status from merge readiness

### DIFF
--- a/.github/workflows/merge-readiness.yml
+++ b/.github/workflows/merge-readiness.yml
@@ -3,11 +3,9 @@ name: Merge Readiness
 on:
   pull_request:
     types:
-      - converted_to_draft
       - edited
       - labeled
       - opened
-      - ready_for_review
       - reopened
       - synchronize
       - unlabeled


### PR DESCRIPTION
## Summary

- Remove the redundant draft-status check from merge-readiness CI.
- Keep readiness evaluation focused on target branch, do-not-merge, and approved[...] labels.
- Rely on GitHub’s draft/published FSM to prevent draft PRs from merging.

## Validation
- actionlint .github/workflows/merge-readiness.yml
- targeted workflow grep found no isDraft/draft lifecycle readiness checks in owned workflow surfaces
