### PR TITLE
ci: remove readiness label triggers

### DIFF
--- a/.github/workflows/merge-readiness.yml
+++ b/.github/workflows/merge-readiness.yml
@@ -3,14 +3,10 @@ name: Merge Readiness
 on:
   pull_request:
     types:
-      - converted_to_draft
       - edited
-      - labeled
       - opened
-      - ready_for_review
       - reopened
       - synchronize
-      - unlabeled
 
 concurrency:
   group: merge-readiness-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- Remove draft lifecycle events from merge-readiness pull_request triggers.
- Keep merge-readiness on the shared `e0da/actions` callable workflow.
- Ensure PR draft state does not drive CI status workflows.

## Validation
- `fd`/`rg` sweep found no remaining approval-label or draft-status gates in active PR branches.
- `actionlint` passed for the changed workflow.
- `git diff --check` passed for the changed workflow.

## Merge Order
- Depends on e0da/actions#22 landing first so the shared callable on `main` is informational instead of label-gated.

## Risk
LOW. Workflow trigger cleanup only; no runtime code changes.
